### PR TITLE
배지 코드 정리

### DIFF
--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/config/SecurityConfig.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/config/SecurityConfig.java
@@ -84,10 +84,10 @@ public class SecurityConfig {
 
                         // [우선순위 3] 비로그인 허용 (Public API - 정보성 데이터)
                         // 메인 페이지 구성에 필요한 기초 정보들은 로그인 없이 GET 허용
-                        .requestMatchers(HttpMethod.GET, "/api/profile-decorations/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/cite/attendance/today").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/cite/category/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/cite/attachments/*/download-url").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/cite/profile-decorations/**").permitAll()
 
                         // [우선순위 4] 인증 필수 API (로그인하지 않으면 접근 불가)
                         // 게시판 조회(GET)를 포함한 모든 게시판 활동은 인증 필요
@@ -111,6 +111,7 @@ public class SecurityConfig {
 
                         // [우선순위 5] 관리자(ADMIN) 전용 API
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/cite/admin/profile-decorations/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/users/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/users/*/role").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/groups", "/api/cite/category/all").hasRole("ADMIN")

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/controller/ProfileDecorationController.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/controller/ProfileDecorationController.java
@@ -6,20 +6,16 @@ import com.nimda.cite.domain.profiledecoration.dto.ProfileDecorationCreateReques
 import com.nimda.cite.domain.profiledecoration.entity.ProfileDecoration;
 import com.nimda.cite.domain.profiledecoration.service.ProfileDecorationService;
 import com.nimda.cite.user.security.CustomUserDetails;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequiredArgsConstructor
+@RequestMapping("/api/cite")
 public class ProfileDecorationController {
 
     private final ProfileDecorationService service;
@@ -27,14 +23,20 @@ public class ProfileDecorationController {
     @Autowired(required = false)
     private S3Service s3Service;
 
-    @GetMapping("/api/profile-decorations")
-    public ResponseEntity<?> getAvailableDecorations(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ProfileDecorationController (ProfileDecorationService profileDecorationService) {
+        this.service = profileDecorationService;
+    }
+
+    @GetMapping("/profile-decorations")
+    public ResponseEntity<?> getAvailableDecorations(
+            @AuthenticationPrincipal CustomUserDetails userDetails)
+    {
         return ApiResponse.ok(
                 service.getAvailableDecorations(userDetails == null ? null : userDetails.getUser())
         ).toResponse();
     }
 
-    @GetMapping("/api/profile-decorations/{key}/image")
+    @GetMapping("/profile-decorations/{key}/image")
     public ResponseEntity<?> getDecorationImage(@PathVariable String key) {
         ProfileDecoration decoration = service.getByKey(key);
         String filePath = decoration.getFilePath();
@@ -55,12 +57,14 @@ public class ProfileDecorationController {
                 .build();
     }
 
-    @GetMapping("/api/admin/profile-decorations")
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/admin/profile-decorations")
     public ResponseEntity<?> getAdminDecorations() {
         return ApiResponse.ok(service.getAllDecorations()).toResponse();
     }
 
-    @PostMapping("/api/admin/profile-decorations")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/admin/profile-decorations")
     public ResponseEntity<?> createDecoration(@RequestBody ProfileDecorationCreateRequest request) {
         try {
             return ApiResponse.ok("프로필 배지가 등록되었습니다.", service.create(request)).toResponse();

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/dto/ProfileDecorationCreateRequest.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/dto/ProfileDecorationCreateRequest.java
@@ -11,6 +11,5 @@ public class ProfileDecorationCreateRequest {
     private String key;
     private String label;
     private String filePath;
-    private String requiredRole;
     private List<String> requiredRoles;
 }

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/service/ProfileDecorationService.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/service/ProfileDecorationService.java
@@ -65,7 +65,8 @@ public class ProfileDecorationService {
         List<String> authorityNames = getAuthorityNames(user);
         boolean hasRoleRestriction = profileDecorationRoleRepository.existsByDecoration(decoration);
         boolean allowedByRole = !hasRoleRestriction
-                || profileDecorationRoleRepository.existsByDecorationAndAuthorityNameIn(decoration, authorityNames);
+                || (!authorityNames.isEmpty()
+                && profileDecorationRoleRepository.existsByDecorationAndAuthorityNameIn(decoration, authorityNames));
         boolean ownedByUser = userProfileDecorationRepository.existsByUserIdAndDecoration(user.getId(), decoration);
 
         if (!allowedByRole && !ownedByUser) {
@@ -138,7 +139,6 @@ public class ProfileDecorationService {
 
     private List<String> normalizeRoles(ProfileDecorationCreateRequest request) {
         Set<String> roles = new LinkedHashSet<>();
-        addRole(roles, request.getRequiredRole());
         if (request.getRequiredRoles() != null) {
             request.getRequiredRoles().forEach(role -> addRole(roles, role));
         }

--- a/NimdaConFrontEnd/src/api/profileDecorations.ts
+++ b/NimdaConFrontEnd/src/api/profileDecorations.ts
@@ -28,7 +28,7 @@ export const getProfileDecorationsAPI = async (): Promise<{
   decorations: ProfileDecorationOption[];
 }> => {
   try {
-    const response = await fetch('/api/profile-decorations', {
+    const response = await fetch('/api/cite/profile-decorations', {
       method: 'GET',
       credentials: 'include',
     });
@@ -54,7 +54,7 @@ export const getProfileDecorationsAPI = async (): Promise<{
 
 export const getAdminProfileDecorationsAPI = async () => {
   try {
-    const response = await fetch('/api/admin/profile-decorations', {
+    const response = await fetch('/api/cite/admin/profile-decorations', {
       method: 'GET',
       credentials: 'include',
     });
@@ -88,7 +88,7 @@ export const createProfileDecorationAPI = async ({
   filePath: string;
 }) => {
   try {
-    const response = await fetch('/api/admin/profile-decorations', {
+    const response = await fetch('/api/cite/admin/profile-decorations', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',

--- a/NimdaConFrontEnd/src/api/profileDecorations.ts
+++ b/NimdaConFrontEnd/src/api/profileDecorations.ts
@@ -9,7 +9,6 @@ export interface ProfileDecorationOption {
   label: string;
   src: string;
   requiredRoles?: string[];
-  requiredRole?: string | null;
   active?: boolean;
 }
 
@@ -80,12 +79,12 @@ export const getAdminProfileDecorationsAPI = async () => {
 export const createProfileDecorationAPI = async ({
   key,
   label,
-  requiredRole,
+  requiredRoles,
   filePath,
 }: {
   key: string;
   label: string;
-  requiredRole?: string | null;
+  requiredRoles?: string[];
   filePath: string;
 }) => {
   try {
@@ -93,7 +92,7 @@ export const createProfileDecorationAPI = async ({
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ key, label, requiredRole, filePath }),
+      body: JSON.stringify({ key, label, requiredRoles: requiredRoles ?? [], filePath }),
     });
     const result = await parseJsonSafe(response);
     if (response.ok && result?.success) {

--- a/NimdaConFrontEnd/src/domains/admin/sections/ProfileDecorationManagement.jsx
+++ b/NimdaConFrontEnd/src/domains/admin/sections/ProfileDecorationManagement.jsx
@@ -70,7 +70,7 @@ const ProfileDecorationManagement = () => {
       const created = await createProfileDecorationAPI({
         key: key.trim(),
         label: label.trim(),
-        requiredRole: requiredRole.trim() || null,
+        requiredRoles: requiredRole.trim() ? [requiredRole.trim()] : [],
         filePath: upload.data.key,
       });
       if (!created.success) {


### PR DESCRIPTION
1. 데이터 모델 및 스토리지 구조 변경
- profile_decorations 테이블 정규화: 기존의 required_role 컬럼을 제거하여 중복 데이터를 방지했습니다.
- 권한 체계 분리:
    - profile_decoration_roles: 특정 권한(Role)이 있어야 사용 가능한 배지 정의
    - user_profile_decorations: 사용자가 직접 구매하거나 지급받아 보유 중인 배지 관리
- 코드 구조화: 프로필 장식 관련 로직을 com.nimda.cite.domain.profiledecoration 패키지 하위로 완전히 독립시켰습니다. (Entity, Repository, Service, Controller, DTO)

2. 비즈니스 로직 최적화
- 의존성 단일화: AuthService에서 직접 장식 테이블을 조회하던 로직을 제거했습니다. 이제 모든 검증은 ProfileDecorationService.validateUsableDecoration()을 통해서만 이루어집니다.
- 서버 사이드 필터링: 기존에 프론트엔드에서 처리하던 권한별 노출 로직을 백엔드로 이관했습니다. /api/profile-decorations 호출 시, DB에서 다음 세 가지 조건을 판단하여 사용 가능한 배지만 반환합니다.
    1. 사용자의 권한에 맞는 배지 (profile_decoration_roles)
    2. 사용자가 보유 중인 배지 (user_profile_decorations)
    3. 아무런 제한이 없는 전체 공개 배지 (권한 설정이 없는 경우)
    
 추가로 고친 것:

  - 프론트 API 요청에서 requiredRole 제거
  - 배지 등록 payload를 requiredRoles: [] / requiredRoles: ["ROLE_ADMIN"] 형태로 변경
  - 백엔드 ProfileDecorationCreateRequest에서도 requiredRole 제거
  - 서비스의 호환 처리 제거
  - 권한 없는 사용자 검증 시 빈 권한 목록으로 IN 쿼리 타지 않도록 방어 처리