### PR TITLE
feat. 마일리지 사용 탭 

### DIFF
--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/attachment/service/AttachmentService.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/attachment/service/AttachmentService.java
@@ -305,6 +305,47 @@ public class AttachmentService {
                 .collect(Collectors.toList());
     }
 
+    public Long resolveThumbnailAttachmentId(List<Long> attachmentIds, Long requestedThumbnailAttachmentId) {
+        if (attachmentIds == null || attachmentIds.isEmpty()) {
+            return null;
+        }
+
+        List<Attachment> imageAttachments = attachmentIds.stream()
+                .filter(id -> id != null)
+                .map(id -> attachmentRepository.findById(id)
+                        .orElseThrow(() -> new RuntimeException("첨부를 찾을 수 없습니다: " + id)))
+                .filter(this::isImage)
+                .sorted((left, right) -> left.getId().compareTo(right.getId()))
+                .toList();
+
+        if (imageAttachments.isEmpty()) {
+            return null;
+        }
+
+        if (requestedThumbnailAttachmentId == null) {
+            return imageAttachments.get(0).getId();
+        }
+
+        return imageAttachments.stream()
+                .filter(attachment -> attachment.getId().equals(requestedThumbnailAttachmentId))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("썸네일은 첨부된 이미지 중에서 선택해야 합니다."))
+                .getId();
+    }
+
+    private boolean isImage(Attachment attachment) {
+        String extension = attachment.getExtension();
+        if (extension == null || extension.isBlank()) {
+            String filename = attachment.getOriginFilename();
+            extension = filename != null && filename.contains(".")
+                    ? filename.substring(filename.lastIndexOf('.') + 1)
+                    : "";
+        }
+
+        return List.of("jpg", "jpeg", "png", "gif", "webp", "bmp", "svg")
+                .contains(extension.toLowerCase());
+    }
+
     /**
      * 게시글 삭제 시 — 연결된 모든 첨부 물리·DB 삭제
      */

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/controller/BoardController.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/controller/BoardController.java
@@ -17,6 +17,8 @@ import com.nimda.cite.domain.comment.repository.CommentRepository;
 import com.nimda.cite.common.response.ApiResponse;
 import com.nimda.cite.common.s3.S3Service;
 import com.nimda.cite.domain.like.service.BoardLikeService;
+import com.nimda.cite.domain.point.entity.UserBalance;
+import com.nimda.cite.domain.point.service.PointService;
 import com.nimda.cite.user.entity.User;
 import com.nimda.cite.user.repository.UserRepository;
 import com.nimda.cite.user.security.CustomUserDetails;
@@ -30,6 +32,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -87,6 +90,9 @@ public class BoardController {
 
     @Autowired
     private CommentRepository commentRepository;
+
+    @Autowired
+    private PointService pointService;
 
     @Autowired(required = false)
     private S3Service s3Service;
@@ -339,7 +345,8 @@ public class BoardController {
             @RequestParam("content") String content,
             @RequestParam(value = "tagId", required = false) Long tagId,
             @RequestParam(value = "attachmentIds", required = false) List<Long> attachmentIds,
-            @RequestParam(value = "pinned", required = false) Boolean pinned) {
+            @RequestParam(value = "pinned", required = false) Boolean pinned,
+            @RequestParam(value = "itemPrice", required = false) Long itemPrice) {
         try {
             if (userDetails == null) {
                 return ApiResponse.fail("로그인이 필요합니다.").toResponse(HttpStatus.UNAUTHORIZED);
@@ -391,11 +398,21 @@ public class BoardController {
                 }
             }
 
+            if (Boolean.TRUE.equals(category.getShopEnabled())) {
+                if (!hasRole(author, "ROLE_ADMIN")) {
+                    return ApiResponse.fail("상품 등록은 관리자만 가능합니다.").toResponse(HttpStatus.FORBIDDEN);
+                }
+                if (itemPrice == null || itemPrice <= 0) {
+                    return ApiResponse.fail("상품 가격을 1 NC 이상으로 입력해주세요.").toResponse(HttpStatus.BAD_REQUEST);
+                }
+            }
+
             Board board = new Board();
             board.setTitle(title);
             board.setContent(content);
             board.setCategory(category);
             board.setTag(tagEntity);
+            board.setItemPrice(Boolean.TRUE.equals(category.getShopEnabled()) ? itemPrice : 0L);
 
             // 관리자만 고정 여부 설정 가능
             if (pinned != null) {
@@ -472,7 +489,8 @@ public class BoardController {
             @RequestParam("content") String content,
             @RequestParam(value = "tagId", required = false) Long tagId,
             @RequestParam(value = "attachmentIds", required = false) List<Long> attachmentIds,
-            @RequestParam(value = "pinned", required = false) Boolean pinned) {
+            @RequestParam(value = "pinned", required = false) Boolean pinned,
+            @RequestParam(value = "itemPrice", required = false) Long itemPrice) {
         try {
             Board boardTemp = boardService.boardView(id);
 
@@ -532,10 +550,20 @@ public class BoardController {
                 }
             }
 
+            if (Boolean.TRUE.equals(category.getShopEnabled())) {
+                if (!isAdmin) {
+                    return ApiResponse.fail("상품 수정은 관리자만 가능합니다.").toResponse(HttpStatus.FORBIDDEN);
+                }
+                if (itemPrice == null || itemPrice <= 0) {
+                    return ApiResponse.fail("상품 가격을 1 NC 이상으로 입력해주세요.").toResponse(HttpStatus.BAD_REQUEST);
+                }
+            }
+
             boardTemp.setTitle(title);
             boardTemp.setContent(content);
             boardTemp.setCategory(category);
             boardTemp.setTag(tagEntity);
+            boardTemp.setItemPrice(Boolean.TRUE.equals(category.getShopEnabled()) ? itemPrice : 0L);
 
             // 관리자만 고정 여부 설정 가능
             if (pinned != null && isAdmin) {
@@ -558,6 +586,51 @@ public class BoardController {
         } catch (Exception e) {
             log.error("게시글 수정 오류", e);
             return ApiResponse.fail("게시글 수정 중 오류가 발생했습니다.")
+                    .toResponse(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @PostMapping("/{id}/purchase")
+    public ResponseEntity<?> purchase(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("id") Long id) {
+        try {
+            if (userDetails == null) {
+                return ApiResponse.fail("로그인이 필요합니다.").toResponse(HttpStatus.UNAUTHORIZED);
+            }
+
+            Board board = boardService.boardView(id);
+            if (board.getStatus() != BoardStatus.ACTIVE) {
+                return ApiResponse.fail("구매할 수 없는 상품입니다.").toResponse(HttpStatus.BAD_REQUEST);
+            }
+            if (board.getCategory() == null || !Boolean.TRUE.equals(board.getCategory().getShopEnabled())) {
+                return ApiResponse.fail("마일리지 구매 상품이 아닙니다.").toResponse(HttpStatus.BAD_REQUEST);
+            }
+            if (board.getItemPrice() == null || board.getItemPrice() <= 0) {
+                return ApiResponse.fail("상품 가격이 설정되지 않았습니다.").toResponse(HttpStatus.BAD_REQUEST);
+            }
+
+            User currentUser = userDetails.getUser();
+            UserBalance balance = pointService.spendBalance(
+                    currentUser.getId(),
+                    "아이템 구매: " + board.getTitle(),
+                    board.getItemPrice()
+            );
+
+            return ApiResponse.ok("구매가 완료되었습니다.", Map.of(
+                    "boardId", board.getId(),
+                    "itemName", board.getTitle(),
+                    "price", board.getItemPrice(),
+                    "remainingAmount", balance.getTotalAmount()
+            )).toResponse();
+        } catch (ResponseStatusException e) {
+            HttpStatus status = HttpStatus.valueOf(e.getStatusCode().value());
+            return ApiResponse.fail(e.getReason() != null ? e.getReason() : "구매에 실패했습니다.").toResponse(status);
+        } catch (RuntimeException e) {
+            return ApiResponse.fail(e.getMessage()).toResponse(HttpStatus.BAD_REQUEST);
+        } catch (Exception e) {
+            log.error("상품 구매 오류", e);
+            return ApiResponse.fail("상품 구매 중 오류가 발생했습니다.")
                     .toResponse(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/controller/BoardController.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/controller/BoardController.java
@@ -8,8 +8,11 @@ import com.nimda.cite.domain.board.dto.CategoryResponseDTO;
 import com.nimda.cite.domain.board.entity.Board;
 import com.nimda.cite.domain.board.entity.Category;
 import com.nimda.cite.domain.board.enums.BoardStatus;
+import com.nimda.cite.domain.board.enums.ShopItemType;
 import com.nimda.cite.domain.board.repository.CategoryRepository;
 import com.nimda.cite.domain.board.service.BoardService;
+import com.nimda.cite.domain.profiledecoration.ProfileDecoration;
+import com.nimda.cite.domain.profiledecoration.ProfileDecorationRepository;
 import com.nimda.cite.domain.tag.entity.Tag;
 import com.nimda.cite.domain.tag.repository.TagRepository;
 import com.nimda.cite.domain.comment.enums.STATUS;
@@ -17,8 +20,6 @@ import com.nimda.cite.domain.comment.repository.CommentRepository;
 import com.nimda.cite.common.response.ApiResponse;
 import com.nimda.cite.common.s3.S3Service;
 import com.nimda.cite.domain.like.service.BoardLikeService;
-import com.nimda.cite.domain.point.entity.UserBalance;
-import com.nimda.cite.domain.point.service.PointService;
 import com.nimda.cite.user.entity.User;
 import com.nimda.cite.user.repository.UserRepository;
 import com.nimda.cite.user.security.CustomUserDetails;
@@ -32,7 +33,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +92,7 @@ public class BoardController {
     private CommentRepository commentRepository;
 
     @Autowired
-    private PointService pointService;
+    private ProfileDecorationRepository profileDecorationRepository;
 
     @Autowired(required = false)
     private S3Service s3Service;
@@ -121,6 +121,16 @@ public class BoardController {
         return false;
     }
 
+    private boolean isShopCategory(Category category) {
+        if (category == null) return false;
+        if (Boolean.TRUE.equals(category.getShopEnabled())) return true;
+        if (category.getParentId() != null) {
+            Category parent = categoryRepository.findById(category.getParentId()).orElse(null);
+            return parent != null && Boolean.TRUE.equals(parent.getShopEnabled());
+        }
+        return false;
+    }
+
     // 사용자가 특정 역할을 보유하는지 확인
     private boolean hasRole(User user, String role) {
         return user != null && user.getAuthorities().stream()
@@ -130,6 +140,36 @@ public class BoardController {
     // 사용자가 해당 게시글을 좋아요 눌렀는지 확인
     private boolean isLiked(Board board, User user) {
         return user != null && boardLikeService.isUserLiked(user.getId(), board.getId());
+    }
+
+    private ShopItemType parseShopItemType(String itemType) {
+        if (itemType == null || itemType.isBlank()) {
+            return ShopItemType.GENERAL;
+        }
+
+        try {
+            return ShopItemType.valueOf(itemType.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("지원하지 않는 상품 종류입니다.");
+        }
+    }
+
+    private ProfileDecoration resolveShopProfileDecoration(ShopItemType itemType, Long profileDecorationId) {
+        if (itemType != ShopItemType.BADGE) {
+            return null;
+        }
+        if (profileDecorationId == null) {
+            throw new IllegalArgumentException("배지 상품은 배지를 선택해야 합니다.");
+        }
+
+        ProfileDecoration decoration = profileDecorationRepository.findById(profileDecorationId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 배지입니다."));
+        if (!decoration.isActive()) {
+            throw new IllegalArgumentException("비활성화된 배지는 상품으로 등록할 수 없습니다.");
+        }
+        decoration.setPurchaseRequired(true);
+        profileDecorationRepository.save(decoration);
+        return decoration;
     }
 
     @GetMapping
@@ -346,7 +386,10 @@ public class BoardController {
             @RequestParam(value = "tagId", required = false) Long tagId,
             @RequestParam(value = "attachmentIds", required = false) List<Long> attachmentIds,
             @RequestParam(value = "pinned", required = false) Boolean pinned,
-            @RequestParam(value = "itemPrice", required = false) Long itemPrice) {
+            @RequestParam(value = "itemPrice", required = false) Long itemPrice,
+            @RequestParam(value = "itemType", required = false) String itemType,
+            @RequestParam(value = "profileDecorationId", required = false) Long profileDecorationId,
+            @RequestParam(value = "thumbnailAttachmentId", required = false) Long thumbnailAttachmentId) {
         try {
             if (userDetails == null) {
                 return ApiResponse.fail("로그인이 필요합니다.").toResponse(HttpStatus.UNAUTHORIZED);
@@ -398,7 +441,8 @@ public class BoardController {
                 }
             }
 
-            if (Boolean.TRUE.equals(category.getShopEnabled())) {
+            boolean isShopCategory = isShopCategory(category);
+            if (isShopCategory) {
                 if (!hasRole(author, "ROLE_ADMIN")) {
                     return ApiResponse.fail("상품 등록은 관리자만 가능합니다.").toResponse(HttpStatus.FORBIDDEN);
                 }
@@ -407,12 +451,29 @@ public class BoardController {
                 }
             }
 
+            ShopItemType resolvedItemType = isShopCategory
+                    ? parseShopItemType(itemType)
+                    : ShopItemType.GENERAL;
+            ProfileDecoration shopDecoration = isShopCategory
+                    ? resolveShopProfileDecoration(resolvedItemType, profileDecorationId)
+                    : null;
+            Long resolvedThumbnailAttachmentId = isShopCategory
+                    ? attachmentService.resolveThumbnailAttachmentId(attachmentIds, thumbnailAttachmentId)
+                    : null;
+            if (isShopCategory && resolvedThumbnailAttachmentId == null) {
+                return ApiResponse.fail("마일리지 상점 상품은 썸네일 이미지가 필요합니다.")
+                        .toResponse(HttpStatus.BAD_REQUEST);
+            }
+
             Board board = new Board();
             board.setTitle(title);
             board.setContent(content);
             board.setCategory(category);
             board.setTag(tagEntity);
-            board.setItemPrice(Boolean.TRUE.equals(category.getShopEnabled()) ? itemPrice : 0L);
+            board.setItemPrice(isShopCategory ? itemPrice : 0L);
+            board.setItemType(resolvedItemType);
+            board.setProfileDecoration(shopDecoration);
+            board.setThumbnailAttachmentId(resolvedThumbnailAttachmentId);
 
             // 관리자만 고정 여부 설정 가능
             if (pinned != null) {
@@ -490,7 +551,10 @@ public class BoardController {
             @RequestParam(value = "tagId", required = false) Long tagId,
             @RequestParam(value = "attachmentIds", required = false) List<Long> attachmentIds,
             @RequestParam(value = "pinned", required = false) Boolean pinned,
-            @RequestParam(value = "itemPrice", required = false) Long itemPrice) {
+            @RequestParam(value = "itemPrice", required = false) Long itemPrice,
+            @RequestParam(value = "itemType", required = false) String itemType,
+            @RequestParam(value = "profileDecorationId", required = false) Long profileDecorationId,
+            @RequestParam(value = "thumbnailAttachmentId", required = false) Long thumbnailAttachmentId) {
         try {
             Board boardTemp = boardService.boardView(id);
 
@@ -550,7 +614,8 @@ public class BoardController {
                 }
             }
 
-            if (Boolean.TRUE.equals(category.getShopEnabled())) {
+            boolean isShopCategory = isShopCategory(category);
+            if (isShopCategory) {
                 if (!isAdmin) {
                     return ApiResponse.fail("상품 수정은 관리자만 가능합니다.").toResponse(HttpStatus.FORBIDDEN);
                 }
@@ -559,11 +624,28 @@ public class BoardController {
                 }
             }
 
+            ShopItemType resolvedItemType = isShopCategory
+                    ? parseShopItemType(itemType)
+                    : ShopItemType.GENERAL;
+            ProfileDecoration shopDecoration = isShopCategory
+                    ? resolveShopProfileDecoration(resolvedItemType, profileDecorationId)
+                    : null;
+            Long resolvedThumbnailAttachmentId = isShopCategory
+                    ? attachmentService.resolveThumbnailAttachmentId(attachmentIds, thumbnailAttachmentId)
+                    : null;
+            if (isShopCategory && resolvedThumbnailAttachmentId == null) {
+                return ApiResponse.fail("마일리지 상점 상품은 썸네일 이미지가 필요합니다.")
+                        .toResponse(HttpStatus.BAD_REQUEST);
+            }
+
             boardTemp.setTitle(title);
             boardTemp.setContent(content);
             boardTemp.setCategory(category);
             boardTemp.setTag(tagEntity);
-            boardTemp.setItemPrice(Boolean.TRUE.equals(category.getShopEnabled()) ? itemPrice : 0L);
+            boardTemp.setItemPrice(isShopCategory ? itemPrice : 0L);
+            boardTemp.setItemType(resolvedItemType);
+            boardTemp.setProfileDecoration(shopDecoration);
+            boardTemp.setThumbnailAttachmentId(resolvedThumbnailAttachmentId);
 
             // 관리자만 고정 여부 설정 가능
             if (pinned != null && isAdmin) {
@@ -586,51 +668,6 @@ public class BoardController {
         } catch (Exception e) {
             log.error("게시글 수정 오류", e);
             return ApiResponse.fail("게시글 수정 중 오류가 발생했습니다.")
-                    .toResponse(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    @PostMapping("/{id}/purchase")
-    public ResponseEntity<?> purchase(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable("id") Long id) {
-        try {
-            if (userDetails == null) {
-                return ApiResponse.fail("로그인이 필요합니다.").toResponse(HttpStatus.UNAUTHORIZED);
-            }
-
-            Board board = boardService.boardView(id);
-            if (board.getStatus() != BoardStatus.ACTIVE) {
-                return ApiResponse.fail("구매할 수 없는 상품입니다.").toResponse(HttpStatus.BAD_REQUEST);
-            }
-            if (board.getCategory() == null || !Boolean.TRUE.equals(board.getCategory().getShopEnabled())) {
-                return ApiResponse.fail("마일리지 구매 상품이 아닙니다.").toResponse(HttpStatus.BAD_REQUEST);
-            }
-            if (board.getItemPrice() == null || board.getItemPrice() <= 0) {
-                return ApiResponse.fail("상품 가격이 설정되지 않았습니다.").toResponse(HttpStatus.BAD_REQUEST);
-            }
-
-            User currentUser = userDetails.getUser();
-            UserBalance balance = pointService.spendBalance(
-                    currentUser.getId(),
-                    "아이템 구매: " + board.getTitle(),
-                    board.getItemPrice()
-            );
-
-            return ApiResponse.ok("구매가 완료되었습니다.", Map.of(
-                    "boardId", board.getId(),
-                    "itemName", board.getTitle(),
-                    "price", board.getItemPrice(),
-                    "remainingAmount", balance.getTotalAmount()
-            )).toResponse();
-        } catch (ResponseStatusException e) {
-            HttpStatus status = HttpStatus.valueOf(e.getStatusCode().value());
-            return ApiResponse.fail(e.getReason() != null ? e.getReason() : "구매에 실패했습니다.").toResponse(status);
-        } catch (RuntimeException e) {
-            return ApiResponse.fail(e.getMessage()).toResponse(HttpStatus.BAD_REQUEST);
-        } catch (Exception e) {
-            log.error("상품 구매 오류", e);
-            return ApiResponse.fail("상품 구매 중 오류가 발생했습니다.")
                     .toResponse(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/BoardResponseDTO.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/BoardResponseDTO.java
@@ -39,6 +39,7 @@ public class BoardResponseDTO {
     private TagInfo tag; // 게시글 태그 (Tag 엔티티 관계)
     private String filename;
     private String filepath;
+    private Long itemPrice;
 
     /** 상세 조회 시에만 채움 — 게시글에 연결된 첨부(S3+Attachment) */
     private List<AttachmentResponseDto> attachments;
@@ -129,6 +130,7 @@ public class BoardResponseDTO {
                 .tag(tagInfo)
                 .filename(board.getFilename())
                 .filepath(board.getFilepath())
+                .itemPrice(board.getItemPrice())
                 .attachments(attachments)
                 .createdAt(board.getCreatedAt())
                 .updatedAt(board.getUpdatedAt())

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/BoardResponseDTO.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/BoardResponseDTO.java
@@ -2,6 +2,7 @@ package com.nimda.cite.domain.board.dto;
 
 import com.nimda.cite.domain.attachment.dto.AttachmentResponseDto;
 import com.nimda.cite.domain.board.entity.Board;
+import com.nimda.cite.domain.profiledecoration.ProfileDecoration;
 import com.nimda.cite.domain.tag.entity.Tag;
 import com.nimda.cite.user.entity.User;
 import lombok.AllArgsConstructor;
@@ -40,6 +41,9 @@ public class BoardResponseDTO {
     private String filename;
     private String filepath;
     private Long itemPrice;
+    private String itemType;
+    private ProfileDecorationInfo profileDecoration;
+    private Long thumbnailAttachmentId;
 
     /** 상세 조회 시에만 채움 — 게시글에 연결된 첨부(S3+Attachment) */
     private List<AttachmentResponseDto> attachments;
@@ -75,6 +79,18 @@ public class BoardResponseDTO {
         private String email;
         private String profileImage;
         private String profileDecoration;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProfileDecorationInfo {
+        private Long id;
+        private String key;
+        private String label;
+        private String src;
     }
 
     /**
@@ -115,6 +131,15 @@ public class BoardResponseDTO {
 
         Tag tag = board.getTag();
         TagInfo tagInfo = tag != null ? TagInfo.builder().id(tag.getId()).tagName(tag.getTagName()).build() : null;
+        ProfileDecoration decoration = board.getProfileDecoration();
+        ProfileDecorationInfo decorationInfo = decoration != null
+                ? ProfileDecorationInfo.builder()
+                        .id(decoration.getId())
+                        .key(decoration.getKey())
+                        .label(decoration.getLabel())
+                        .src("/api/cite/profile-decorations/" + decoration.getKey() + "/image")
+                        .build()
+                : null;
 
         return BoardResponseDTO.builder()
                 .id(board.getId())
@@ -131,6 +156,9 @@ public class BoardResponseDTO {
                 .filename(board.getFilename())
                 .filepath(board.getFilepath())
                 .itemPrice(board.getItemPrice())
+                .itemType(board.getItemType() != null ? board.getItemType().name() : null)
+                .profileDecoration(decorationInfo)
+                .thumbnailAttachmentId(board.getThumbnailAttachmentId())
                 .attachments(attachments)
                 .createdAt(board.getCreatedAt())
                 .updatedAt(board.getUpdatedAt())

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/CategoryCreateDTO.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/CategoryCreateDTO.java
@@ -68,4 +68,6 @@ public class CategoryCreateDTO {
      */
     @Size(max = 500, message = "URL은 500자를 초과할 수 없습니다")
     private String redirectUrl;
+
+    private Boolean shopEnabled;
 }

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/CategoryResponseDTO.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/CategoryResponseDTO.java
@@ -29,6 +29,7 @@ public class CategoryResponseDTO {
     private Integer sortOrder;
     private Integer postCount;
     private String redirectUrl;  // 바로가기 URL (외부 링크, null이면 일반 게시판)
+    private Boolean shopEnabled;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -53,6 +54,7 @@ public class CategoryResponseDTO {
                 .sortOrder(category.getSortOrder())
                 .postCount(category.getPostCount())
                 .redirectUrl(category.getRedirectUrl())
+                .shopEnabled(category.getShopEnabled())
                 .createdAt(category.getCreatedAt())
                 .updatedAt(category.getUpdatedAt())
                 .build();

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/CategoryUpdateDTO.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/CategoryUpdateDTO.java
@@ -67,4 +67,6 @@ public class CategoryUpdateDTO {
      */
     @Size(max = 500, message = "URL은 500자를 초과할 수 없습니다")
     private String redirectUrl;
+
+    private Boolean shopEnabled;
 }

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/entity/Board.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/entity/Board.java
@@ -33,6 +33,8 @@ package com.nimda.cite.domain.board.entity;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.nimda.cite.domain.board.enums.BoardStatus;
+import com.nimda.cite.domain.board.enums.ShopItemType;
+import com.nimda.cite.domain.profiledecoration.ProfileDecoration;
 import com.nimda.cite.domain.tag.entity.Tag;
 import com.nimda.cite.common.entity.BaseTimeEntity;
 import com.nimda.cite.user.entity.User;
@@ -120,6 +122,18 @@ public class Board extends BaseTimeEntity {
 
     @Column(name = "item_price", nullable = false)
     private Long itemPrice = 0L;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "item_type", nullable = false, length = 30)
+    private ShopItemType itemType = ShopItemType.GENERAL;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_decoration_id")
+    @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
+    private ProfileDecoration profileDecoration;
+
+    @Column(name = "thumbnail_attachment_id")
+    private Long thumbnailAttachmentId;
 
     // ========== [Soft Delete 지원] ==========
     // [신규] 게시글 상태 필드 추가

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/entity/Board.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/entity/Board.java
@@ -118,6 +118,9 @@ public class Board extends BaseTimeEntity {
     @Column(length = 500)
     private String filepath;
 
+    @Column(name = "item_price", nullable = false)
+    private Long itemPrice = 0L;
+
     // ========== [Soft Delete 지원] ==========
     // [신규] 게시글 상태 필드 추가
     // [이유] 삭제 시 실제 DB 삭제 대신 상태를 DELETED로 변경 (soft delete)

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/entity/Category.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/entity/Category.java
@@ -81,4 +81,8 @@ public class Category extends BaseTimeEntity {
     @Column(name = "redirect_url", nullable = true, length = 500)
     private String redirectUrl;
 
+    @Column(name = "shop_enabled", nullable = false)
+    @Builder.Default
+    private Boolean shopEnabled = false;
+
 }

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/enums/ShopItemType.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/enums/ShopItemType.java
@@ -1,0 +1,6 @@
+package com.nimda.cite.domain.board.enums;
+
+public enum ShopItemType {
+    GENERAL,
+    BADGE
+}

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/service/CategoryService.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/service/CategoryService.java
@@ -118,6 +118,7 @@ public class CategoryService {
                 .isActive(createDTO.getIsActive() != null ? createDTO.getIsActive() : true)
                 .postCount(0)
                 .redirectUrl(createDTO.getRedirectUrl() != null && !createDTO.getRedirectUrl().isBlank() ? createDTO.getRedirectUrl().trim() : null)
+                .shopEnabled(createDTO.getShopEnabled() != null ? createDTO.getShopEnabled() : false)
                 .build();
 
         // 4. 저장 및 반환
@@ -184,6 +185,9 @@ public class CategoryService {
         if (updateDTO.getRedirectUrl() != null) {
             // 빈 문자열이면 null로 설정 (URL 제거), 아니면 트림 후 저장
             category.setRedirectUrl(updateDTO.getRedirectUrl().isBlank() ? null : updateDTO.getRedirectUrl().trim());
+        }
+        if (updateDTO.getShopEnabled() != null) {
+            category.setShopEnabled(updateDTO.getShopEnabled());
         }
 
         // 5. 저장 및 반환

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/point/service/PointService.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/point/service/PointService.java
@@ -108,36 +108,6 @@ public class PointService {
     }
 
     @Transactional
-    public UserBalance spendBalance(Long userId, String description, Long pointAmount) {
-        if (pointAmount == null || pointAmount <= 0) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "차감할 마일리지가 올바르지 않습니다.");
-        }
-
-        UserBalance balance = userBalanceRepository.findById(userId).orElseThrow(
-                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "포인트 계좌가 존재하지 않습니다.")
-        );
-
-        if (balance.getTotalAmount() < pointAmount) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "보유 마일리지가 부족합니다.");
-        }
-
-        balance.setUpdatedAt(LocalDateTime.now());
-        balance.setTotalAmount(balance.getTotalAmount() - pointAmount);
-
-        PointDetail pointDetail = PointDetail.builder()
-                .userBalance(balance)
-                .amount(-pointAmount)
-                .description(description)
-                .createdAt(LocalDateTime.now())
-                .expiredAt(LocalDateTime.now().plusYears(1L))
-                .remainingAmount(balance.getTotalAmount())
-                .build();
-
-        pointDetailRepository.save(pointDetail);
-        return balance;
-    }
-
-    @Transactional
     public List<UserBalance> updateBalanceManualBulk(List<ManualBalanceUpdateRequest> requests) {
         List<UserBalance> results = new ArrayList<>();
 

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/point/service/PointService.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/point/service/PointService.java
@@ -108,6 +108,36 @@ public class PointService {
     }
 
     @Transactional
+    public UserBalance spendBalance(Long userId, String description, Long pointAmount) {
+        if (pointAmount == null || pointAmount <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "차감할 마일리지가 올바르지 않습니다.");
+        }
+
+        UserBalance balance = userBalanceRepository.findById(userId).orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "포인트 계좌가 존재하지 않습니다.")
+        );
+
+        if (balance.getTotalAmount() < pointAmount) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "보유 마일리지가 부족합니다.");
+        }
+
+        balance.setUpdatedAt(LocalDateTime.now());
+        balance.setTotalAmount(balance.getTotalAmount() - pointAmount);
+
+        PointDetail pointDetail = PointDetail.builder()
+                .userBalance(balance)
+                .amount(-pointAmount)
+                .description(description)
+                .createdAt(LocalDateTime.now())
+                .expiredAt(LocalDateTime.now().plusYears(1L))
+                .remainingAmount(balance.getTotalAmount())
+                .build();
+
+        pointDetailRepository.save(pointDetail);
+        return balance;
+    }
+
+    @Transactional
     public List<UserBalance> updateBalanceManualBulk(List<ManualBalanceUpdateRequest> requests) {
         List<UserBalance> results = new ArrayList<>();
 

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/point/usage/controller/PointUsageController.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/point/usage/controller/PointUsageController.java
@@ -1,0 +1,40 @@
+package com.nimda.cite.domain.point.usage.controller;
+
+import com.nimda.cite.common.response.ApiResponse;
+import com.nimda.cite.domain.point.usage.dto.PointUsageResponse;
+import com.nimda.cite.domain.point.usage.service.PointUsageService;
+import com.nimda.cite.user.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/cite/board")
+@RequiredArgsConstructor
+public class PointUsageController {
+
+    private final PointUsageService pointUsageService;
+
+    @PostMapping("/{id}/purchase")
+    public ResponseEntity<?> purchase(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("id") Long id) {
+        if (userDetails == null) {
+            return ApiResponse.fail("로그인이 필요합니다.").toResponse(HttpStatus.UNAUTHORIZED);
+        }
+
+        try {
+            PointUsageResponse response = pointUsageService.purchaseBoardItem(userDetails.getUser().getId(), id);
+            return ApiResponse.ok("구매가 완료되었습니다.", response).toResponse();
+        } catch (ResponseStatusException e) {
+            HttpStatus status = HttpStatus.valueOf(e.getStatusCode().value());
+            return ApiResponse.fail(e.getReason() != null ? e.getReason() : "구매에 실패했습니다.").toResponse(status);
+        }
+    }
+}

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/point/usage/dto/PointUsageResponse.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/point/usage/dto/PointUsageResponse.java
@@ -1,0 +1,15 @@
+package com.nimda.cite.domain.point.usage.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PointUsageResponse {
+    private Long boardId;
+    private String itemName;
+    private Long price;
+    private Long remainingAmount;
+    private String itemType;
+    private String profileDecorationKey;
+}

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/point/usage/service/PointUsageService.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/point/usage/service/PointUsageService.java
@@ -1,0 +1,141 @@
+package com.nimda.cite.domain.point.usage.service;
+
+import com.nimda.cite.domain.board.entity.Board;
+import com.nimda.cite.domain.board.enums.BoardStatus;
+import com.nimda.cite.domain.board.enums.ShopItemType;
+import com.nimda.cite.domain.board.repository.BoardRepository;
+import com.nimda.cite.domain.point.entity.PointDetail;
+import com.nimda.cite.domain.point.entity.UserBalance;
+import com.nimda.cite.domain.point.repositroy.PointDetailRepository;
+import com.nimda.cite.domain.point.repositroy.UserBalanceRepository;
+import com.nimda.cite.domain.point.usage.dto.PointUsageResponse;
+import com.nimda.cite.domain.profiledecoration.ProfileDecoration;
+import com.nimda.cite.domain.profiledecoration.ownership.ProfileDecorationOwnershipService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PointUsageService {
+
+    private static final Logger log = LoggerFactory.getLogger(PointUsageService.class);
+
+    private final BoardRepository boardRepository;
+    private final UserBalanceRepository userBalanceRepository;
+    private final PointDetailRepository pointDetailRepository;
+    private final ProfileDecorationOwnershipService profileDecorationOwnershipService;
+
+    @Transactional
+    public PointUsageResponse purchaseBoardItem(Long userId, Long boardId) {
+        try {
+            Board board = boardRepository.findById(boardId)
+                    .orElseThrow(() -> new ResponseStatusException(
+                            HttpStatus.BAD_REQUEST,
+                            "게시글을 찾을 수 없습니다: " + boardId
+                    ));
+
+            validatePurchasable(board);
+            validateNotAlreadyOwned(userId, board);
+            ShopItemType itemType = resolveItemType(board);
+
+            UserBalance balance = spendBalance(
+                    userId,
+                    "아이템 구매: " + board.getTitle(),
+                    board.getItemPrice()
+            );
+
+            return PointUsageResponse.builder()
+                    .boardId(board.getId())
+                    .itemName(board.getTitle())
+                    .price(board.getItemPrice())
+                    .remainingAmount(balance.getTotalAmount())
+                    .itemType(itemType.name())
+                    .profileDecorationKey(grantPurchasedItem(userId, board))
+                    .build();
+        } catch (ResponseStatusException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            log.error("상품 구매 처리 오류", e);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+        } catch (Exception e) {
+            log.error("상품 구매 오류", e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "상품 구매 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    private void validatePurchasable(Board board) {
+        if (board.getStatus() != BoardStatus.ACTIVE) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "구매할 수 없는 상품입니다.");
+        }
+        if (board.getCategory() == null || !Boolean.TRUE.equals(board.getCategory().getShopEnabled())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "마일리지 구매 상품이 아닙니다.");
+        }
+        if (board.getItemPrice() == null || board.getItemPrice() <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "상품 가격이 설정되지 않았습니다.");
+        }
+        if (resolveItemType(board) == ShopItemType.BADGE && board.getProfileDecoration() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "상품에 연결된 배지가 없습니다.");
+        }
+    }
+
+    private void validateNotAlreadyOwned(Long userId, Board board) {
+        if (resolveItemType(board) != ShopItemType.BADGE) {
+            return;
+        }
+
+        ProfileDecoration decoration = board.getProfileDecoration();
+        if (profileDecorationOwnershipService.owns(userId, decoration.getId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미 보유한 배지입니다.");
+        }
+    }
+
+    private String grantPurchasedItem(Long userId, Board board) {
+        if (resolveItemType(board) != ShopItemType.BADGE) {
+            return null;
+        }
+
+        ProfileDecoration decoration = board.getProfileDecoration();
+        profileDecorationOwnershipService.grant(userId, decoration);
+        return decoration.getKey();
+    }
+
+    private ShopItemType resolveItemType(Board board) {
+        return board.getItemType() == null ? ShopItemType.GENERAL : board.getItemType();
+    }
+
+    private UserBalance spendBalance(Long userId, String description, Long pointAmount) {
+        if (pointAmount == null || pointAmount <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "차감할 마일리지가 올바르지 않습니다.");
+        }
+
+        UserBalance balance = userBalanceRepository.findById(userId).orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "포인트 계좌가 존재하지 않습니다.")
+        );
+
+        if (balance.getTotalAmount() < pointAmount) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "보유 마일리지가 부족합니다.");
+        }
+
+        balance.setUpdatedAt(LocalDateTime.now());
+        balance.setTotalAmount(balance.getTotalAmount() - pointAmount);
+
+        PointDetail pointDetail = PointDetail.builder()
+                .userBalance(balance)
+                .amount(-pointAmount)
+                .description(description)
+                .createdAt(LocalDateTime.now())
+                .expiredAt(LocalDateTime.now().plusYears(1L))
+                .remainingAmount(balance.getTotalAmount())
+                .build();
+
+        pointDetailRepository.save(pointDetail);
+        return balance;
+    }
+}

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ProfileDecoration.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ProfileDecoration.java
@@ -31,6 +31,9 @@ public class ProfileDecoration extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean active = true;
 
+    @Column(name = "purchase_required", nullable = false)
+    private boolean purchaseRequired = false;
+
     public ProfileDecoration(String key, String label, String filePath) {
         this.key = key;
         this.label = label;
@@ -42,5 +45,9 @@ public class ProfileDecoration extends BaseTimeEntity {
         this.filePath = filePath;
         this.requiredRole = requiredRole;
         this.active = active;
+    }
+
+    public void setPurchaseRequired(boolean purchaseRequired) {
+        this.purchaseRequired = purchaseRequired;
     }
 }

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ProfileDecorationController.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ProfileDecorationController.java
@@ -2,11 +2,14 @@ package com.nimda.cite.domain.profiledecoration;
 
 import com.nimda.cite.common.response.ApiResponse;
 import com.nimda.cite.common.s3.S3Service;
+import com.nimda.cite.domain.profiledecoration.ownership.ProfileDecorationOwnershipService;
+import com.nimda.cite.user.security.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,12 +17,16 @@ import org.springframework.web.bind.annotation.*;
 public class ProfileDecorationController {
 
     private final ProfileDecorationService service;
+    private final ProfileDecorationOwnershipService ownershipService;
 
     @Autowired(required = false)
     private S3Service s3Service;
 
-    public ProfileDecorationController(ProfileDecorationService profileDecorationService) {
+    public ProfileDecorationController(
+            ProfileDecorationService profileDecorationService,
+            ProfileDecorationOwnershipService ownershipService) {
         this.service = profileDecorationService;
+        this.ownershipService = ownershipService;
     }
 
     @GetMapping("/profile-decorations")
@@ -50,6 +57,19 @@ public class ProfileDecorationController {
         return ResponseEntity.status(HttpStatus.FOUND)
                 .header(HttpHeaders.LOCATION, url)
                 .build();
+    }
+
+    @GetMapping("/profile-decorations/me")
+    public ResponseEntity<?> getMyDecorations(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            return ApiResponse.fail("로그인이 필요합니다.").toResponse(HttpStatus.UNAUTHORIZED);
+        }
+
+        return ApiResponse.ok(
+                ownershipService.getOwnedDecorations(userDetails.getUser().getId()).stream()
+                        .map(ProfileDecorationDto::from)
+                        .toList()
+        ).toResponse();
     }
 
     @PreAuthorize("hasRole('ADMIN')")

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ProfileDecorationCreateRequest.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ProfileDecorationCreateRequest.java
@@ -10,4 +10,5 @@ public class ProfileDecorationCreateRequest {
     private String label;
     private String filePath;
     private String requiredRole;
+    private Boolean purchaseRequired;
 }

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ProfileDecorationDto.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ProfileDecorationDto.java
@@ -11,6 +11,7 @@ public class ProfileDecorationDto {
     private String label;
     private String src;
     private String requiredRole;
+    private boolean purchaseRequired;
     private boolean active;
 
     public static ProfileDecorationDto from(ProfileDecoration decoration) {
@@ -20,6 +21,7 @@ public class ProfileDecorationDto {
                 .label(decoration.getLabel())
                 .src("/api/cite/profile-decorations/" + decoration.getKey() + "/image")
                 .requiredRole(decoration.getRequiredRole())
+                .purchaseRequired(decoration.isPurchaseRequired())
                 .active(decoration.isActive())
                 .build();
     }

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ProfileDecorationService.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ProfileDecorationService.java
@@ -35,6 +35,7 @@ public class ProfileDecorationService {
         String label = request.getLabel() == null ? "" : request.getLabel().trim();
         String filePath = request.getFilePath() == null ? "" : request.getFilePath().trim();
         String requiredRole = normalizeRole(request.getRequiredRole());
+        boolean purchaseRequired = Boolean.TRUE.equals(request.getPurchaseRequired());
 
         if (key.isBlank()) {
             throw new IllegalArgumentException("배지 키를 입력해주세요.");
@@ -54,6 +55,7 @@ public class ProfileDecorationService {
 
         ProfileDecoration decoration = new ProfileDecoration(key, label, filePath);
         decoration.update(label, filePath, requiredRole, true);
+        decoration.setPurchaseRequired(purchaseRequired);
         return repository.save(decoration);
     }
 

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ownership/ProfileDecorationOwnershipService.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ownership/ProfileDecorationOwnershipService.java
@@ -1,0 +1,39 @@
+package com.nimda.cite.domain.profiledecoration.ownership;
+
+import com.nimda.cite.domain.profiledecoration.ProfileDecoration;
+import com.nimda.cite.user.entity.User;
+import com.nimda.cite.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileDecorationOwnershipService {
+
+    private final UserProfileDecorationRepository repository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public boolean owns(Long userId, Long profileDecorationId) {
+        return repository.existsByUserIdAndProfileDecorationId(userId, profileDecorationId);
+    }
+
+    @Transactional
+    public void grant(Long userId, ProfileDecoration profileDecoration) {
+        if (owns(userId, profileDecoration.getId())) {
+            return;
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        repository.save(new UserProfileDecoration(user, profileDecoration));
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProfileDecoration> getOwnedDecorations(Long userId) {
+        return repository.findDecorationsByUserId(userId);
+    }
+}

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ownership/UserProfileDecoration.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ownership/UserProfileDecoration.java
@@ -1,0 +1,48 @@
+package com.nimda.cite.domain.profiledecoration.ownership;
+
+import com.nimda.cite.domain.profiledecoration.ProfileDecoration;
+import com.nimda.cite.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "user_profile_decorations",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "profile_decoration_id"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserProfileDecoration {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_decoration_id", nullable = false)
+    private ProfileDecoration profileDecoration;
+
+    private LocalDateTime acquiredAt;
+
+    public UserProfileDecoration(User user, ProfileDecoration profileDecoration) {
+        this.user = user;
+        this.profileDecoration = profileDecoration;
+        this.acquiredAt = LocalDateTime.now();
+    }
+}

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ownership/UserProfileDecorationRepository.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/profiledecoration/ownership/UserProfileDecorationRepository.java
@@ -1,0 +1,21 @@
+package com.nimda.cite.domain.profiledecoration.ownership;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface UserProfileDecorationRepository extends JpaRepository<UserProfileDecoration, Long> {
+    boolean existsByUserIdAndProfileDecorationId(Long userId, Long profileDecorationId);
+
+    List<UserProfileDecoration> findByUserIdOrderByAcquiredAtDesc(Long userId);
+
+    @Query("""
+            select upd.profileDecoration
+            from UserProfileDecoration upd
+            where upd.user.id = :userId
+            order by upd.acquiredAt desc
+            """)
+    List<com.nimda.cite.domain.profiledecoration.ProfileDecoration> findDecorationsByUserId(@Param("userId") Long userId);
+}

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/user/service/AuthService.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/user/service/AuthService.java
@@ -9,6 +9,7 @@ import com.nimda.cite.user.enums.ApprovalStatus;
 import com.nimda.cite.user.exception.UserNotApprovedException;
 import com.nimda.cite.domain.profiledecoration.ProfileDecoration;
 import com.nimda.cite.domain.profiledecoration.ProfileDecorationRepository;
+import com.nimda.cite.domain.profiledecoration.ownership.ProfileDecorationOwnershipService;
 import com.nimda.cite.common.util.JwtUtil;
 import com.nimda.cite.user.repository.UserRepository;
 import com.nimda.cite.user.security.CustomUserDetails;
@@ -43,6 +44,9 @@ public class AuthService {
     private UserRepository userRepository;
     @Autowired
     private ProfileDecorationRepository profileDecorationRepository;
+
+    @Autowired
+    private ProfileDecorationOwnershipService profileDecorationOwnershipService;
     @Autowired
     private RedisUtil redisUtil;
 
@@ -212,6 +216,10 @@ public class AuthService {
             if (!allowed) {
                 throw new SecurityException("이 프로필 장식을 사용할 권한이 없습니다.");
             }
+        }
+        if (decoration.isPurchaseRequired()
+                && !profileDecorationOwnershipService.owns(userId, decoration.getId())) {
+            throw new SecurityException("구매한 프로필 장식만 사용할 수 있습니다.");
         }
 
         user.setProfileDecoration(

--- a/NimdaConBackEnd/backend-spring/src/main/resources/db/migration/V25__Add_shop_board_fields.sql
+++ b/NimdaConBackEnd/backend-spring/src/main/resources/db/migration/V25__Add_shop_board_fields.sql
@@ -1,0 +1,13 @@
+ALTER TABLE category
+    ADD COLUMN shop_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE category
+SET shop_enabled = FALSE
+WHERE shop_enabled IS NULL;
+
+ALTER TABLE board
+    ADD COLUMN item_price BIGINT NOT NULL DEFAULT 0;
+
+UPDATE board
+SET item_price = 0
+WHERE item_price IS NULL;

--- a/NimdaConBackEnd/backend-spring/src/main/resources/db/migration/V26__Add_badge_shop_purchase.sql
+++ b/NimdaConBackEnd/backend-spring/src/main/resources/db/migration/V26__Add_badge_shop_purchase.sql
@@ -1,0 +1,23 @@
+ALTER TABLE profile_decorations
+    ADD COLUMN purchase_required BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE board
+    ADD COLUMN item_type VARCHAR(30) NOT NULL DEFAULT 'GENERAL',
+    ADD COLUMN profile_decoration_id BIGINT NULL;
+
+ALTER TABLE board
+    ADD CONSTRAINT fk_board_profile_decoration
+        FOREIGN KEY (profile_decoration_id) REFERENCES profile_decorations(id);
+
+CREATE TABLE user_profile_decorations (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    profile_decoration_id BIGINT NOT NULL,
+    acquired_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_user_profile_decoration (user_id, profile_decoration_id),
+    CONSTRAINT fk_user_profile_decorations_user
+        FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT fk_user_profile_decorations_decoration
+        FOREIGN KEY (profile_decoration_id) REFERENCES profile_decorations(id)
+);

--- a/NimdaConBackEnd/backend-spring/src/main/resources/db/migration/V27__Add_board_thumbnail_attachment.sql
+++ b/NimdaConBackEnd/backend-spring/src/main/resources/db/migration/V27__Add_board_thumbnail_attachment.sql
@@ -1,0 +1,2 @@
+ALTER TABLE board
+    ADD COLUMN thumbnail_attachment_id BIGINT NULL;

--- a/NimdaConFrontEnd/src/App.css
+++ b/NimdaConFrontEnd/src/App.css
@@ -2100,6 +2100,79 @@ body {
   color: #d64454;
 }
 
+.bw-thumbnail-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  background: #fafafa;
+}
+
+.bw-thumbnail-picker__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.bw-thumbnail-picker__header span {
+  font-size: 14px;
+  font-weight: 700;
+  color: #404040;
+}
+
+.bw-thumbnail-picker__header small {
+  font-size: 12px;
+  color: #8f8f8f;
+  text-align: right;
+}
+
+.bw-thumbnail-picker__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+  gap: 10px;
+}
+
+.bw-thumbnail-option {
+  position: relative;
+  height: 96px;
+  padding: 0;
+  overflow: hidden;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  background: #eeeeee;
+  cursor: pointer;
+}
+
+.bw-thumbnail-option img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.bw-thumbnail-option span {
+  position: absolute;
+  left: 6px;
+  bottom: 6px;
+  padding: 4px 7px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.72);
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.bw-thumbnail-option--selected {
+  border-color: #d97399;
+}
+
+.bw-thumbnail-option--auto {
+  border-color: #9ca3af;
+}
+
 /* ── 고정 옵션 체크박스 ── */
 .bw-checkbox-label {
   display: flex;

--- a/NimdaConFrontEnd/src/Router.tsx
+++ b/NimdaConFrontEnd/src/Router.tsx
@@ -18,7 +18,7 @@ import ProtectedRoute from "@/components/ProtectedRoute";
 import ForbiddenPage from "@/domains/Error/403";
 
 import ContestHome from "@/domains/Contest/Home";
-import BoardListPage from "@/domains/Board/BoardList";
+import BoardRoutePage from "@/domains/Board/BoardRoute";
 import BoardDetailPage from "@/domains/Board/BoardDetail";
 import BoardWritePage from "@/domains/Board/BoardWrite";
 import BoardEditPage from "@/domains/Board/BoardEdit";
@@ -48,7 +48,7 @@ const Router = () => {
         <Route path="/user/:nickname" element={<UserProfilePage />} />
         <Route path="/board/picture-board" element={<PhotoGalleryBoard boardSlug="picture-board" boardTitle="사진첩" />} />
         <Route path="/board/banner" element={<PhotoGalleryBoard boardSlug="banner" boardTitle="배너" adminOnlyWrite={true} />} />
-        <Route path="/board/:boardType" element={<BoardListPage />} />
+        <Route path="/board/:boardType" element={<BoardRoutePage />} />
         <Route path="/board/:boardType/:id" element={<BoardDetailPage />} />
 
         {/* 로그인 필수 경로 */}

--- a/NimdaConFrontEnd/src/api/board.ts
+++ b/NimdaConFrontEnd/src/api/board.ts
@@ -187,6 +187,9 @@ export const createBoardAPI = async (
     if (data.pinned !== undefined) {
       formData.append('pinned', String(data.pinned));
     }
+    if (data.itemPrice != null) {
+      formData.append('itemPrice', String(data.itemPrice));
+    }
     // multipart `file` 제거됨 — 이유: 백엔드는 S3 presigned 후 `attachmentIds`만 받음.
     if (data.attachmentIds !== undefined && data.attachmentIds.length > 0) {
       for (const aid of data.attachmentIds) {
@@ -254,6 +257,9 @@ export const updateBoardAPI = async (
     }
     if (data.pinned !== undefined) {
       formData.append('pinned', String(data.pinned));
+    }
+    if (data.itemPrice != null) {
+      formData.append('itemPrice', String(data.itemPrice));
     }
     // 수정 시 생략하면 첨부 동기화 안 함. 전달 시 최종 목록으로 동기화(빈 배열 = 전부 삭제).
     if (data.attachmentIds !== undefined) {
@@ -606,6 +612,52 @@ export const toggleBoardLikeAPI = async (
   }
 };
 
+export interface BoardPurchaseResponse {
+  success: boolean;
+  message: string;
+  data?: {
+    boardId: number;
+    itemName: string;
+    price: number;
+    remainingAmount: number;
+  };
+}
+
+export const purchaseBoardItemAPI = async (
+  boardId: number
+): Promise<BoardPurchaseResponse | BoardErrorResponse> => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/${boardId}/purchase`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+    });
+
+    const result = await parseJsonSafe(response);
+
+    if (response.ok && result?.success) {
+      return {
+        success: true,
+        message: result.message || '구매가 완료되었습니다.',
+        data: result.data || result,
+      };
+    }
+
+    return {
+      success: false,
+      message: (result?.message as string) || '구매에 실패했습니다.',
+    };
+  } catch (error) {
+    console.error('상품 구매 API 오류:', error);
+    return {
+      success: false,
+      message: '상품 구매 중 오류가 발생했습니다.',
+    };
+  }
+};
+
 /**
  * 게시글 고정/해제 토글 API
  * 
@@ -783,4 +835,3 @@ export const deleteMyBoardsAPI = async (boardIds: number[]): Promise<{ success: 
     return { success: false, message: '게시글 삭제 중 오류가 발생했습니다.' };
   }
 };
-

--- a/NimdaConFrontEnd/src/api/board.ts
+++ b/NimdaConFrontEnd/src/api/board.ts
@@ -190,6 +190,15 @@ export const createBoardAPI = async (
     if (data.itemPrice != null) {
       formData.append('itemPrice', String(data.itemPrice));
     }
+    if (data.itemType) {
+      formData.append('itemType', data.itemType);
+    }
+    if (data.profileDecorationId != null) {
+      formData.append('profileDecorationId', String(data.profileDecorationId));
+    }
+    if (data.thumbnailAttachmentId != null) {
+      formData.append('thumbnailAttachmentId', String(data.thumbnailAttachmentId));
+    }
     // multipart `file` 제거됨 — 이유: 백엔드는 S3 presigned 후 `attachmentIds`만 받음.
     if (data.attachmentIds !== undefined && data.attachmentIds.length > 0) {
       for (const aid of data.attachmentIds) {
@@ -260,6 +269,15 @@ export const updateBoardAPI = async (
     }
     if (data.itemPrice != null) {
       formData.append('itemPrice', String(data.itemPrice));
+    }
+    if (data.itemType) {
+      formData.append('itemType', data.itemType);
+    }
+    if (data.profileDecorationId != null) {
+      formData.append('profileDecorationId', String(data.profileDecorationId));
+    }
+    if (data.thumbnailAttachmentId != null) {
+      formData.append('thumbnailAttachmentId', String(data.thumbnailAttachmentId));
     }
     // 수정 시 생략하면 첨부 동기화 안 함. 전달 시 최종 목록으로 동기화(빈 배열 = 전부 삭제).
     if (data.attachmentIds !== undefined) {
@@ -620,6 +638,8 @@ export interface BoardPurchaseResponse {
     itemName: string;
     price: number;
     remainingAmount: number;
+    itemType?: string;
+    profileDecorationKey?: string | null;
   };
 }
 

--- a/NimdaConFrontEnd/src/api/category.ts
+++ b/NimdaConFrontEnd/src/api/category.ts
@@ -161,6 +161,7 @@ export interface CategoryCreateRequest {
   parentId?: number | null;
   sortOrder?: number | null;
   isActive?: boolean | null;
+  shopEnabled?: boolean | null;
 }
 
 /**
@@ -172,6 +173,7 @@ export interface CategoryUpdateRequest {
   parentId?: number | null;
   sortOrder?: number | null;
   isActive?: boolean | null;
+  shopEnabled?: boolean | null;
 }
 
 /**

--- a/NimdaConFrontEnd/src/api/profileDecorations.ts
+++ b/NimdaConFrontEnd/src/api/profileDecorations.ts
@@ -9,6 +9,7 @@ export interface ProfileDecorationOption {
   label: string;
   src: string;
   requiredRole?: string | null;
+  purchaseRequired?: boolean;
   active?: boolean;
 }
 
@@ -76,23 +77,53 @@ export const getAdminProfileDecorationsAPI = async () => {
   }
 };
 
+export const getMyProfileDecorationsAPI = async (): Promise<{
+  success: boolean;
+  message?: string;
+  decorations: ProfileDecorationOption[];
+}> => {
+  try {
+    const response = await fetch('/api/cite/profile-decorations/me', {
+      method: 'GET',
+      credentials: 'include',
+    });
+    const result = await parseJsonSafe(response);
+    if (response.ok && result?.success) {
+      return { success: true, decorations: result.data ?? [] };
+    }
+    return {
+      success: false,
+      message: result?.message || '보유한 프로필 배지 목록을 불러오지 못했습니다.',
+      decorations: [],
+    };
+  } catch {
+    return {
+      success: false,
+      message: '보유한 프로필 배지 목록을 불러오지 못했습니다.',
+      decorations: [],
+    };
+  }
+};
+
 export const createProfileDecorationAPI = async ({
   key,
   label,
   requiredRole,
   filePath,
+  purchaseRequired,
 }: {
   key: string;
   label: string;
   requiredRole?: string | null;
   filePath: string;
+  purchaseRequired?: boolean;
 }) => {
   try {
     const response = await fetch('/api/cite/admin/profile-decorations', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ key, label, requiredRole, filePath }),
+      body: JSON.stringify({ key, label, requiredRole, filePath, purchaseRequired }),
     });
     const result = await parseJsonSafe(response);
     if (response.ok && result?.success) {

--- a/NimdaConFrontEnd/src/domains/Board/BoardDetail/BoardDetail.css
+++ b/NimdaConFrontEnd/src/domains/Board/BoardDetail/BoardDetail.css
@@ -491,3 +491,118 @@
   color: var(--color-gray-500);
   font-size: 14px;
 }
+
+.board-detail__shop {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.board-detail__shop-top {
+  display: grid;
+  grid-template-columns: minmax(280px, 420px) minmax(0, 1fr);
+  gap: 36px;
+  align-items: start;
+  margin-top: 24px;
+}
+
+.board-detail__shop-image-wrap {
+  overflow: hidden;
+  border: 1px solid #dedede;
+  border-radius: 8px;
+  background: #eeeeee;
+  aspect-ratio: 1 / 1;
+}
+
+.board-detail__shop-image,
+.board-detail__shop-image-placeholder {
+  width: 100%;
+  height: 100%;
+}
+
+.board-detail__shop-image {
+  object-fit: cover;
+}
+
+.board-detail__shop-image-placeholder {
+  background:
+    linear-gradient(135deg, rgba(217, 115, 153, 0.16), rgba(75, 162, 233, 0.12)),
+    #eeeeee;
+}
+
+.board-detail__shop-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+
+.board-detail__shop-tag {
+  align-self: flex-start;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: #0c0c0c;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.board-detail__shop-title {
+  margin: 0;
+  color: #0c0c0c;
+  font-size: 28px;
+  font-weight: 800;
+  line-height: 1.3;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+.board-detail__shop-price {
+  padding: 18px 0;
+  border-top: 1px solid #dedede;
+  border-bottom: 1px solid #dedede;
+  color: #d97399;
+  font-size: 30px;
+  font-weight: 900;
+  line-height: 1.1;
+}
+
+.board-detail__shop-buy {
+  width: 100%;
+  height: 48px;
+  border: 0;
+  border-radius: 8px;
+  background: #d97399;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.board-detail__shop-buy:hover:not(:disabled) {
+  background: #c45d84;
+}
+
+.board-detail__shop-buy:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.board-detail__shop-description {
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid #dedede;
+}
+
+.board-detail__shop-description h2 {
+  margin: 0 0 16px;
+  color: #0c0c0c;
+  font-size: 18px;
+  font-weight: 800;
+}
+
+@media (max-width: 820px) {
+  .board-detail__shop-top {
+    grid-template-columns: 1fr;
+  }
+}

--- a/NimdaConFrontEnd/src/domains/Board/BoardDetail/index.tsx
+++ b/NimdaConFrontEnd/src/domains/Board/BoardDetail/index.tsx
@@ -4,12 +4,13 @@ import DOMPurify, { type Config as DOMPurifyConfig } from 'dompurify';
 import { MessageBox } from '@/components/icons/MessageBox';
 import { VerticalDots } from '@/components/icons/VerticalDots';
 import Layout from '@/components/Layout';
-import { openAttachmentDownloadInNewTab } from '@/api/attachments';
+import { getAttachmentPresignedUrl, openAttachmentDownloadInNewTab } from '@/api/attachments';
 import {
   getBoardDetailAPI,
   deleteBoardAPI,
   getFileDownloadURL,
   getBoardLikeStatusAPI,
+  purchaseBoardItemAPI,
 } from '@/api/board';
 import { getAllCategoriesAPI } from '@/api/category';
 import { hasRole, isAdmin, getCurrentNickname } from '@/utils/jwt';
@@ -22,6 +23,16 @@ import { highlightCodeBlocks } from '@/utils/codeHighlight';
 import './BoardDetail.css';
 
 const MAX_VIEWER_FONT_SIZE_PX = 24;
+const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg'];
+
+const getFirstImageAttachmentId = (board: Board): number | null => {
+  if (!board.attachments || board.attachments.length === 0) return null;
+  for (const attachment of board.attachments) {
+    const ext = attachment.originFilename?.split('.').pop()?.toLowerCase() || '';
+    if (!attachment.originFilename || IMAGE_EXTENSIONS.includes(ext)) return attachment.id;
+  }
+  return null;
+};
 
 const normalizeViewerFontSize = (size: string, fallbackPx = 14) => {
   const match = size
@@ -149,6 +160,8 @@ function BoardDetailPage() {
   const [isLiked, setIsLiked] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [showAttachments, setShowAttachments] = useState(false);
+  const [shopImageUrl, setShopImageUrl] = useState<string | null>(null);
+  const [isPurchasing, setIsPurchasing] = useState(false);
   const normalizedViewerContent = sanitizeViewerContent(board?.content ?? '');
   const bodyRef = useRef<HTMLDivElement>(null);
 
@@ -162,6 +175,34 @@ function BoardDetailPage() {
       highlightCodeBlocks(body);
     }
   }, [normalizedViewerContent]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadShopImage = async () => {
+      if (!board?.category?.shopEnabled) {
+        setShopImageUrl(null);
+        return;
+      }
+
+      const attachmentId = getFirstImageAttachmentId(board);
+      if (!attachmentId) {
+        setShopImageUrl(null);
+        return;
+      }
+
+      try {
+        const url = await getAttachmentPresignedUrl(attachmentId);
+        if (!cancelled) setShopImageUrl(url);
+      } catch {
+        if (!cancelled) setShopImageUrl(null);
+      }
+    };
+
+    loadShopImage();
+    return () => {
+      cancelled = true;
+    };
+  }, [board]);
 
   const fetchBoard = async (boardId: number) => {
     try {
@@ -253,6 +294,33 @@ function BoardDetailPage() {
     }
   };
 
+  const handlePurchase = async () => {
+    if (!board || isPurchasing) return;
+    const price = board.itemPrice ?? 0;
+    if (price <= 0) {
+      alert('상품 가격이 설정되지 않았습니다.');
+      return;
+    }
+    if (!window.confirm(`${board.title} 상품을 ${price.toLocaleString()} NC에 구매하시겠습니까?`)) {
+      return;
+    }
+
+    setIsPurchasing(true);
+    try {
+      const result = await purchaseBoardItemAPI(board.id);
+      if (result.success) {
+        const remaining = 'data' in result && result.data?.remainingAmount != null
+          ? `\n잔여 마일리지: ${result.data.remainingAmount.toLocaleString()} NC`
+          : '';
+        alert(`${result.message}${remaining}`);
+      } else {
+        alert(result.message || '구매에 실패했습니다.');
+      }
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
   const isAuthor = () =>
     !!board &&
     !!board.author?.nickname &&
@@ -291,6 +359,102 @@ function BoardDetailPage() {
           >
             목록으로
           </button>
+        </div>
+      </Layout>
+    );
+  }
+
+  if (board.category?.shopEnabled) {
+    return (
+      <Layout>
+        <div className="board-detail__shop">
+          <button
+            type="button"
+            onClick={handleGoBack}
+            className="board-detail__back"
+          >
+            ← {board.category?.name ?? '마일리지 상점'}
+          </button>
+
+          <section className="board-detail__shop-top">
+            <div className="board-detail__shop-image-wrap">
+              {shopImageUrl ? (
+                <img src={shopImageUrl} alt={board.title} className="board-detail__shop-image" />
+              ) : (
+                <div className="board-detail__shop-image-placeholder" />
+              )}
+            </div>
+
+            <div className="board-detail__shop-panel">
+              {board.tag?.tagName && (
+                <span className="board-detail__shop-tag">{board.tag.tagName}</span>
+              )}
+              <div className="board-detail__title-row">
+                <h1 className="board-detail__shop-title">{board.title}</h1>
+                {(isAuthor() || isAdmin()) && (
+                  <div className="board-detail__menu-wrap">
+                    <button
+                      type="button"
+                      className="board-detail__more-btn"
+                      aria-label="더보기"
+                      onClick={() => setMenuOpen((prev) => !prev)}
+                    >
+                      <VerticalDots size={24} />
+                    </button>
+                    {menuOpen && (
+                      <ul className="board-detail__menu">
+                        {isAuthor() && (
+                          <li>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setMenuOpen(false);
+                                handleEdit();
+                              }}
+                            >
+                              수정
+                            </button>
+                          </li>
+                        )}
+                        <li>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setMenuOpen(false);
+                              void handleDelete();
+                            }}
+                            disabled={isDeleting}
+                          >
+                            {isDeleting ? '삭제 중...' : '삭제'}
+                          </button>
+                        </li>
+                      </ul>
+                    )}
+                  </div>
+                )}
+              </div>
+              <div className="board-detail__shop-price">
+                {(board.itemPrice ?? 0).toLocaleString()} NC
+              </div>
+              <button
+                type="button"
+                className="board-detail__shop-buy"
+                onClick={handlePurchase}
+                disabled={isPurchasing}
+              >
+                {isPurchasing ? '구매 처리 중...' : '구매하기'}
+              </button>
+            </div>
+          </section>
+
+          <section className="board-detail__shop-description">
+            <h2>상품 상세설명</h2>
+            <div
+              ref={bodyRef}
+              className="board-detail__body board-detail__content-scope"
+              dangerouslySetInnerHTML={{ __html: normalizedViewerContent }}
+            />
+          </section>
         </div>
       </Layout>
     );

--- a/NimdaConFrontEnd/src/domains/Board/BoardDetail/index.tsx
+++ b/NimdaConFrontEnd/src/domains/Board/BoardDetail/index.tsx
@@ -312,7 +312,10 @@ function BoardDetailPage() {
         const remaining = 'data' in result && result.data?.remainingAmount != null
           ? `\n잔여 마일리지: ${result.data.remainingAmount.toLocaleString()} NC`
           : '';
-        alert(`${result.message}${remaining}`);
+        const badge = 'data' in result && result.data?.profileDecorationKey
+          ? '\n구매한 배지가 마이페이지에 지급되었습니다.'
+          : '';
+        alert(`${result.message}${badge}${remaining}`);
       } else {
         alert(result.message || '구매에 실패했습니다.');
       }
@@ -436,6 +439,11 @@ function BoardDetailPage() {
               <div className="board-detail__shop-price">
                 {(board.itemPrice ?? 0).toLocaleString()} NC
               </div>
+              {board.itemType === 'BADGE' && board.profileDecoration && (
+                <div className="board-detail__shop-price" style={{ fontSize: '14px' }}>
+                  지급 배지: {board.profileDecoration.label}
+                </div>
+              )}
               <button
                 type="button"
                 className="board-detail__shop-buy"

--- a/NimdaConFrontEnd/src/domains/Board/BoardRoute/index.tsx
+++ b/NimdaConFrontEnd/src/domains/Board/BoardRoute/index.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import BoardListPage from '@/domains/Board/BoardList';
+import ShopBoard from '@/domains/Board/ShopBoard';
+import { getCategoryBySlugAPI } from '@/api/category';
+import type { Category } from '@/domains/Board/types';
+
+function BoardRoutePage() {
+  const { boardType } = useParams<{ boardType: string }>();
+  const slug = boardType?.toLowerCase() || 'news';
+  const [category, setCategory] = useState<Category | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getCategoryBySlugAPI(slug)
+      .then((nextCategory) => {
+        if (!cancelled) setCategory(nextCategory);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  if (loading) return <BoardListPage slug={slug} />;
+  if (category?.shopEnabled) return <ShopBoard boardSlug={slug} />;
+  return <BoardListPage slug={slug} />;
+}
+
+export default BoardRoutePage;

--- a/NimdaConFrontEnd/src/domains/Board/BoardWrite/AttachmentSection.tsx
+++ b/NimdaConFrontEnd/src/domains/Board/BoardWrite/AttachmentSection.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import type { TagResponse } from '@/api/tag';
 import { formatFileSize } from './constants';
 
+const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg'];
+
+const isImageFile = (file: { name: string }) => {
+  const ext = file.name.split('.').pop()?.toLowerCase() || '';
+  return IMAGE_EXTENSIONS.includes(ext);
+};
+
 interface AttachmentSectionProps {
   // Tags
   currentTagList: TagResponse[];
@@ -11,6 +18,9 @@ interface AttachmentSectionProps {
 
   // Files
   attachedFiles: { id: number; name: string; size: number; isInline?: boolean }[];
+  isShopCategory: boolean;
+  thumbnailAttachmentId: number | null;
+  setThumbnailAttachmentId: (id: number | null) => void;
   isDragOver: boolean;
   isUploading: boolean;
   handleDragOver: (e: React.DragEvent) => void;
@@ -29,6 +39,9 @@ export default function AttachmentSection({
   setTagId,
   detailCategoryWarningRef,
   attachedFiles,
+  isShopCategory,
+  thumbnailAttachmentId,
+  setThumbnailAttachmentId,
   isDragOver,
   isUploading,
   handleDragOver,
@@ -40,6 +53,11 @@ export default function AttachmentSection({
   handleFileSelect,
   handleImageSelect,
 }: AttachmentSectionProps) {
+  const imageFiles = attachedFiles
+    .filter(isImageFile)
+    .sort((left, right) => left.id - right.id);
+  const automaticThumbnailId = imageFiles[0]?.id ?? null;
+
   return (
     <>
       {/* ── 태그 선택 (Tag 엔티티 기반) ── */}
@@ -85,6 +103,42 @@ export default function AttachmentSection({
       {/* ── 첨부파일 ── */}
       <div className="bw-section">
         <span className="bw-section-label">첨부파일</span>
+        {isShopCategory && (
+          <div className="bw-thumbnail-picker">
+            <div className="bw-thumbnail-picker__header">
+              <span>상품 썸네일</span>
+              <small>
+                사진을 클릭하면 썸네일로 지정되고, 다시 클릭하면 자동 지정으로 돌아갑니다.
+              </small>
+            </div>
+            {imageFiles.length > 0 ? (
+              <div className="bw-thumbnail-picker__grid">
+                {imageFiles.map((file) => {
+                  const selected = thumbnailAttachmentId === file.id;
+                  const automatic = thumbnailAttachmentId == null && automaticThumbnailId === file.id;
+                  return (
+                    <button
+                      key={file.id}
+                      type="button"
+                      className={`bw-thumbnail-option ${selected ? 'bw-thumbnail-option--selected' : ''} ${automatic ? 'bw-thumbnail-option--auto' : ''}`}
+                      onClick={() => setThumbnailAttachmentId(selected ? null : file.id)}
+                    >
+                      <img
+                        src={`/api/cite/attachments/${file.id}/download?disposition=inline`}
+                        alt={file.name}
+                      />
+                      {(selected || automatic) && (
+                        <span>{selected ? '썸네일' : '자동 썸네일'}</span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            ) : (
+              <p className="bw-tag-hint">마일리지 상점 상품은 이미지 첨부가 필요합니다.</p>
+            )}
+          </div>
+        )}
         {attachedFiles.some((f) => !f.isInline) && (
           <div className="bw-file-list">
             {attachedFiles

--- a/NimdaConFrontEnd/src/domains/Board/BoardWrite/index.tsx
+++ b/NimdaConFrontEnd/src/domains/Board/BoardWrite/index.tsx
@@ -13,6 +13,10 @@ import { uploadBoardFileViaS3 } from '@/api/attachments';
 import { getAllCategoriesAPI } from '@/api/category';
 import { getTagsByCategoryAPI } from '@/api/tag';
 import type { TagResponse } from '@/api/tag';
+import {
+  getAdminProfileDecorationsAPI,
+  type ProfileDecorationOption,
+} from '@/api/profileDecorations';
 import { getEmoticonSrc } from '@/domains/Comment/EmoticonPicker';
 import { hasRole, isAdmin } from '@/utils/jwt';
 import CategorySelector from './CategorySelector';
@@ -24,6 +28,14 @@ import { FontSize, ResolvedTextStyle, RichCodeBlock, RichImage, lowlight } from 
 import { getSanitizedEditorHtml } from './editorUtils';
 
 const EMPTY_DOC = '<p></p>';
+const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg'];
+
+type AttachedFile = { id: number; name: string; size: number; isInline?: boolean };
+
+const isImageAttachment = (file: AttachedFile) => {
+  const ext = file.name.split('.').pop()?.toLowerCase() || '';
+  return IMAGE_EXTENSIONS.includes(ext);
+};
 
 const normalizeLinkUrl = (value: string) => {
   const trimmed = value.trim();
@@ -35,6 +47,13 @@ const normalizeLinkUrl = (value: string) => {
 const hasMeaningfulContent = (html: string) => {
   const textOnly = html.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').trim();
   return textOnly.length > 0 || /<img\b/i.test(html);
+};
+
+const isShopCategoryGroup = (category: Category, categories: Category[]) => {
+  if (category.shopEnabled) return true;
+  if (category.parentId == null) return false;
+  const parent = categories.find((item) => item.id === category.parentId);
+  return Boolean(parent?.shopEnabled);
 };
 
 function BoardWritePage() {
@@ -55,10 +74,12 @@ function BoardWritePage() {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState(EMPTY_DOC);
   const [itemPrice, setItemPrice] = useState('');
+  const [itemType, setItemType] = useState<'GENERAL' | 'BADGE'>('GENERAL');
+  const [profileDecorationId, setProfileDecorationId] = useState<number | null>(null);
+  const [profileDecorations, setProfileDecorations] = useState<ProfileDecorationOption[]>([]);
+  const [thumbnailAttachmentId, setThumbnailAttachmentId] = useState<number | null>(null);
   const [tagId, setTagId] = useState<number | null>(null);
-  const [attachedFiles, setAttachedFiles] = useState<
-    { id: number; name: string; size: number; isInline?: boolean }[]
-  >([]);
+  const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>([]);
   const [editBoardId, setEditBoardId] = useState<number | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -176,7 +197,7 @@ function BoardWritePage() {
         .filter((category) => category.parentId === null && category.isActive)
         .filter((category) => !['바로가기', '대회'].includes(category.name))
         .filter((category) => category.name !== '새 소식' || isAdmin())
-        .filter((category) => !category.shopEnabled || isAdmin())
+        .filter((category) => !isShopCategoryGroup(category, allCategories) || isAdmin())
         .filter(
           (category) =>
             category.name !== '카르텔' || hasRole('ROLE_CARTEL') || isAdmin()
@@ -194,7 +215,36 @@ function BoardWritePage() {
     (category) => category.id === subCategoryId
   );
   const targetCategoryId = currentSubCat?.id ?? currentParentCat?.id ?? null;
-  const isShopCategory = Boolean(currentSubCat?.shopEnabled ?? currentParentCat?.shopEnabled);
+  const selectedCategory = currentSubCat ?? currentParentCat ?? null;
+  const isShopCategory = selectedCategory
+    ? isShopCategoryGroup(selectedCategory, allCategories)
+    : false;
+
+  useEffect(() => {
+    if (!isShopCategory || !isAdmin()) {
+      setProfileDecorations([]);
+      setItemType('GENERAL');
+      setProfileDecorationId(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadProfileDecorations = async () => {
+      const result = await getAdminProfileDecorationsAPI();
+      if (!cancelled && result.success) {
+        setProfileDecorations(
+          result.decorations.filter((decoration) => decoration.active !== false)
+        );
+      }
+    };
+
+    void loadProfileDecorations();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isShopCategory]);
 
   const pushRecentColor = (color: string) => {
     setRecentColors((prev) => {
@@ -305,7 +355,7 @@ function BoardWritePage() {
       return;
     }
 
-    if (matchedCategory?.shopEnabled && !isAdmin()) {
+    if (matchedCategory && isShopCategoryGroup(matchedCategory, allCategories) && !isAdmin()) {
       alert('상품 등록은 관리자만 가능합니다.');
       navigate(`/board/${matchedCategory.slug}`);
       return;
@@ -320,6 +370,9 @@ function BoardWritePage() {
             setEditBoardId(board.id);
             setTitle(board.title);
             setItemPrice(board.itemPrice != null ? String(board.itemPrice) : '');
+            setItemType(board.itemType === 'BADGE' ? 'BADGE' : 'GENERAL');
+            setProfileDecorationId(board.profileDecoration?.id ?? null);
+            setThumbnailAttachmentId(board.thumbnailAttachmentId ?? null);
             setTagId(board.tag?.id ?? null);
             setAttachedFiles(
               board.attachments?.map((attachment) => ({
@@ -509,6 +562,7 @@ function BoardWritePage() {
 
   const handleRemoveFile = (attachmentId: number) => {
     setAttachedFiles((prev) => prev.filter((file) => file.id !== attachmentId));
+    setThumbnailAttachmentId((current) => (current === attachmentId ? null : current));
   };
 
   const handleDragOver = (event: React.DragEvent) => {
@@ -583,6 +637,19 @@ function BoardWritePage() {
       setError('상품 가격을 1 NC 이상으로 입력해주세요.');
       return;
     }
+    if (isShopCategory && itemType === 'BADGE' && !profileDecorationId) {
+      setError('배지 상품으로 등록하려면 지급할 배지를 선택해주세요.');
+      return;
+    }
+    const imageAttachments = attachedFiles.filter(isImageAttachment);
+    const resolvedThumbnailAttachmentId =
+      thumbnailAttachmentId && imageAttachments.some((file) => file.id === thumbnailAttachmentId)
+        ? thumbnailAttachmentId
+        : null;
+    if (isShopCategory && imageAttachments.length === 0) {
+      setError('마일리지 상점 상품은 썸네일로 사용할 이미지를 첨부해야 합니다.');
+      return;
+    }
 
     if (currentTagList.length > 0 && tagId === null) {
       setError(null);
@@ -612,6 +679,9 @@ function BoardWritePage() {
           tagId: tagId ?? undefined,
           attachmentIds,
           itemPrice: isShopCategory ? parsedItemPrice : null,
+          itemType: isShopCategory ? itemType : 'GENERAL',
+          profileDecorationId: isShopCategory && itemType === 'BADGE' ? profileDecorationId : null,
+          thumbnailAttachmentId: isShopCategory ? resolvedThumbnailAttachmentId : null,
         });
 
         if (response.success && 'board' in response) {
@@ -631,6 +701,9 @@ function BoardWritePage() {
         tagId: tagId ?? undefined,
         attachmentIds,
         itemPrice: isShopCategory ? parsedItemPrice : null,
+        itemType: isShopCategory ? itemType : 'GENERAL',
+        profileDecorationId: isShopCategory && itemType === 'BADGE' ? profileDecorationId : null,
+        thumbnailAttachmentId: isShopCategory ? resolvedThumbnailAttachmentId : null,
       });
 
       if (response.success && 'board' in response) {
@@ -716,6 +789,54 @@ function BoardWritePage() {
                   required
                 />
               </div>
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'minmax(0, 180px) minmax(0, 1fr)',
+                  gap: '14px',
+                  alignItems: 'center',
+                }}
+              >
+                <select
+                  value={itemType}
+                  onChange={(event) => {
+                    const nextType = event.target.value as 'GENERAL' | 'BADGE';
+                    setItemType(nextType);
+                    if (nextType !== 'BADGE') {
+                      setProfileDecorationId(null);
+                    }
+                  }}
+                  className="bw-title-input"
+                  aria-label="상품 종류"
+                  style={{ fontSize: '16px' }}
+                >
+                  <option value="GENERAL">일반 상품</option>
+                  <option value="BADGE">배지 상품</option>
+                </select>
+                <select
+                  value={profileDecorationId ?? ''}
+                  onChange={(event) =>
+                    setProfileDecorationId(
+                      event.target.value ? Number(event.target.value) : null
+                    )
+                  }
+                  className="bw-title-input"
+                  aria-label="지급 배지"
+                  disabled={itemType !== 'BADGE'}
+                  style={{ fontSize: '16px', opacity: itemType === 'BADGE' ? 1 : 0.45 }}
+                >
+                  <option value="">
+                    {itemType === 'BADGE'
+                      ? '구매자에게 지급할 배지를 선택하세요'
+                      : '배지 상품일 때만 선택'}
+                  </option>
+                  {profileDecorations.map((decoration) => (
+                    <option key={decoration.id ?? decoration.key} value={decoration.id}>
+                      {decoration.label} ({decoration.key})
+                    </option>
+                  ))}
+                </select>
+              </div>
             </>
           )}
 
@@ -764,6 +885,9 @@ function BoardWritePage() {
             setTagId={setTagId}
             detailCategoryWarningRef={detailCategoryWarningRef}
             attachedFiles={attachedFiles}
+            isShopCategory={isShopCategory}
+            thumbnailAttachmentId={thumbnailAttachmentId}
+            setThumbnailAttachmentId={setThumbnailAttachmentId}
             isDragOver={isDragOver}
             isUploading={isUploading}
             handleDragOver={handleDragOver}

--- a/NimdaConFrontEnd/src/domains/Board/BoardWrite/index.tsx
+++ b/NimdaConFrontEnd/src/domains/Board/BoardWrite/index.tsx
@@ -54,6 +54,7 @@ function BoardWritePage() {
 
   const [title, setTitle] = useState('');
   const [content, setContent] = useState(EMPTY_DOC);
+  const [itemPrice, setItemPrice] = useState('');
   const [tagId, setTagId] = useState<number | null>(null);
   const [attachedFiles, setAttachedFiles] = useState<
     { id: number; name: string; size: number; isInline?: boolean }[]
@@ -175,6 +176,7 @@ function BoardWritePage() {
         .filter((category) => category.parentId === null && category.isActive)
         .filter((category) => !['바로가기', '대회'].includes(category.name))
         .filter((category) => category.name !== '새 소식' || isAdmin())
+        .filter((category) => !category.shopEnabled || isAdmin())
         .filter(
           (category) =>
             category.name !== '카르텔' || hasRole('ROLE_CARTEL') || isAdmin()
@@ -192,6 +194,7 @@ function BoardWritePage() {
     (category) => category.id === subCategoryId
   );
   const targetCategoryId = currentSubCat?.id ?? currentParentCat?.id ?? null;
+  const isShopCategory = Boolean(currentSubCat?.shopEnabled ?? currentParentCat?.shopEnabled);
 
   const pushRecentColor = (color: string) => {
     setRecentColors((prev) => {
@@ -302,6 +305,12 @@ function BoardWritePage() {
       return;
     }
 
+    if (matchedCategory?.shopEnabled && !isAdmin()) {
+      alert('상품 등록은 관리자만 가능합니다.');
+      navigate(`/board/${matchedCategory.slug}`);
+      return;
+    }
+
     if (isEditMode && editId) {
       const loadBoard = async () => {
         try {
@@ -310,6 +319,7 @@ function BoardWritePage() {
             const board = response.board;
             setEditBoardId(board.id);
             setTitle(board.title);
+            setItemPrice(board.itemPrice != null ? String(board.itemPrice) : '');
             setTagId(board.tag?.id ?? null);
             setAttachedFiles(
               board.attachments?.map((attachment) => ({
@@ -568,6 +578,12 @@ function BoardWritePage() {
       return;
     }
 
+    const parsedItemPrice = itemPrice.trim() ? Number(itemPrice) : null;
+    if (isShopCategory && (!Number.isFinite(parsedItemPrice) || !parsedItemPrice || parsedItemPrice <= 0)) {
+      setError('상품 가격을 1 NC 이상으로 입력해주세요.');
+      return;
+    }
+
     if (currentTagList.length > 0 && tagId === null) {
       setError(null);
       requestAnimationFrame(() => {
@@ -595,6 +611,7 @@ function BoardWritePage() {
           content: latestContent,
           tagId: tagId ?? undefined,
           attachmentIds,
+          itemPrice: isShopCategory ? parsedItemPrice : null,
         });
 
         if (response.success && 'board' in response) {
@@ -613,6 +630,7 @@ function BoardWritePage() {
         content: latestContent,
         tagId: tagId ?? undefined,
         attachmentIds,
+        itemPrice: isShopCategory ? parsedItemPrice : null,
       });
 
       if (response.success && 'board' in response) {
@@ -681,6 +699,25 @@ function BoardWritePage() {
               required
             />
           </div>
+
+          {isShopCategory && (
+            <>
+              <div className="bw-divider" />
+              <div className="bw-title-area">
+                <input
+                  id="bw-item-price"
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={itemPrice}
+                  onChange={(event) => setItemPrice(event.target.value)}
+                  placeholder="상품 가격을 입력하세요. 예: 1200"
+                  className="bw-title-input"
+                  required
+                />
+              </div>
+            </>
+          )}
 
           <div className="bw-divider" />
 

--- a/NimdaConFrontEnd/src/domains/Board/ShopBoard/ShopBoard.css
+++ b/NimdaConFrontEnd/src/domains/Board/ShopBoard/ShopBoard.css
@@ -1,0 +1,126 @@
+.shop-board {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.shop-board__toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+  margin: 18px 0 8px;
+}
+
+.shop-board__summary {
+  margin: 0;
+  color: #737373;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.shop-board__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 22px;
+}
+
+.shop-board__card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid #dedede;
+  border-radius: 8px;
+  background: #fff;
+  transition: transform 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.shop-board__card:hover {
+  transform: translateY(-2px);
+  border-color: #d97399;
+  box-shadow: 0 10px 26px rgba(12, 12, 12, 0.08);
+}
+
+.shop-board__image-wrap {
+  position: relative;
+  background: #eeeeee;
+  aspect-ratio: 1 / 1;
+}
+
+.shop-board__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.shop-board__image-placeholder {
+  width: 100%;
+  height: 100%;
+  background:
+    linear-gradient(135deg, rgba(217, 115, 153, 0.16), rgba(75, 162, 233, 0.12)),
+    #eeeeee;
+}
+
+.shop-board__tag {
+  position: absolute;
+  left: 10px;
+  top: 10px;
+  max-width: calc(100% - 20px);
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(12, 12, 12, 0.78);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.shop-board__info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+}
+
+.shop-board__name {
+  margin: 0;
+  min-height: 42px;
+  color: #0c0c0c;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.shop-board__price {
+  color: #d97399;
+  font-size: 16px;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+@media (max-width: 900px) {
+  .shop-board__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .shop-board__toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .shop-board__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/NimdaConFrontEnd/src/domains/Board/ShopBoard/index.tsx
+++ b/NimdaConFrontEnd/src/domains/Board/ShopBoard/index.tsx
@@ -1,0 +1,215 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import Layout from '@/components/Layout';
+import { getAttachmentPresignedUrl } from '@/api/attachments';
+import { getBoardDetailAPI, getBoardListAPI } from '@/api/board';
+import { getAllCategoriesAPI } from '@/api/category';
+import { getTagsByCategoryAPI } from '@/api/tag';
+import { isAdmin } from '@/utils/jwt';
+import type { Board } from '@/domains/Board/types';
+import '@/domains/Board/BoardList/BoardList.css';
+import './ShopBoard.css';
+
+const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg'];
+const PAGE_SIZE = 12;
+
+const getFirstImageAttachmentId = (board: Board): number | null => {
+  if (!board.attachments || board.attachments.length === 0) return null;
+  for (const attachment of board.attachments) {
+    const ext = attachment.originFilename?.split('.').pop()?.toLowerCase() || '';
+    if (!attachment.originFilename || IMAGE_EXTENSIONS.includes(ext)) return attachment.id;
+  }
+  return null;
+};
+
+interface ShopBoardProps {
+  boardSlug: string;
+}
+
+const ShopBoard: React.FC<ShopBoardProps> = ({ boardSlug }) => {
+  const navigate = useNavigate();
+  const [posts, setPosts] = useState<Board[]>([]);
+  const [thumbnails, setThumbnails] = useState<Record<number, string | null>>({});
+  const [loading, setLoading] = useState(true);
+  const [categoryName, setCategoryName] = useState('마일리지 상점');
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [availableTags, setAvailableTags] = useState<string[]>([]);
+
+  const loadPosts = useCallback(async (page: number) => {
+    setLoading(true);
+    try {
+      const result = await getBoardListAPI({
+        slug: boardSlug,
+        page,
+        size: PAGE_SIZE,
+        sort: 'createdAt,desc',
+      });
+
+      if (result.success) {
+        setPosts(result.posts);
+        setTotalPages(result.totalPages);
+        setCategoryName(result.category?.name || '마일리지 상점');
+
+        const thumbMap: Record<number, string | null> = {};
+        await Promise.all(
+          result.posts.map(async (post) => {
+            try {
+              const detail = await getBoardDetailAPI(post.id);
+              if (detail.success && 'board' in detail) {
+                const attachmentId = getFirstImageAttachmentId(detail.board);
+                thumbMap[post.id] = attachmentId ? await getAttachmentPresignedUrl(attachmentId) : null;
+              } else {
+                thumbMap[post.id] = null;
+              }
+            } catch {
+              thumbMap[post.id] = null;
+            }
+          })
+        );
+        setThumbnails(thumbMap);
+      } else {
+        setPosts([]);
+        setTotalPages(0);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [boardSlug]);
+
+  useEffect(() => {
+    loadPosts(currentPage);
+  }, [currentPage, loadPosts]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchTags = async () => {
+      try {
+        const categories = await getAllCategoriesAPI();
+        const category = categories.find((item) => item.slug === boardSlug);
+        if (!category?.id) return;
+        const tags = await getTagsByCategoryAPI(category.id);
+        if (!cancelled) setAvailableTags(tags.map((tag) => tag.tagName));
+      } catch {
+        if (!cancelled) setAvailableTags([]);
+      }
+    };
+
+    fetchTags();
+    return () => {
+      cancelled = true;
+    };
+  }, [boardSlug]);
+
+  const displayPosts = selectedTag
+    ? posts.filter((post) => post.tag?.tagName === selectedTag)
+    : posts;
+
+  const renderPageNumbers = () => {
+    const pages: number[] = [];
+    const maxVisible = 5;
+    let start = Math.max(0, currentPage - Math.floor(maxVisible / 2));
+    const end = Math.min(totalPages, start + maxVisible);
+    if (end - start < maxVisible) start = Math.max(0, end - maxVisible);
+    for (let i = start; i < end; i += 1) pages.push(i);
+    return pages;
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <Layout>
+      <div className="board-list shop-board">
+        <div className="board-list__header">
+          <h1 className="board-list__title">{categoryName}</h1>
+          {isAdmin() && (
+            <button
+              className="board-list__write-btn"
+              onClick={() => navigate(`/board/${boardSlug}/write`)}
+              aria-label="상품 등록"
+            >
+              +
+            </button>
+          )}
+        </div>
+
+        {availableTags.length > 0 && (
+          <div className="board-list__tag-filter">
+            <button
+              className={`board-list__tag-filter-item ${selectedTag === null ? 'board-list__tag-filter-item--active' : ''}`}
+              onClick={() => setSelectedTag(null)}
+            >
+              전체
+            </button>
+            {availableTags.map((tag) => (
+              <button
+                key={tag}
+                className={`board-list__tag-filter-item ${selectedTag === tag ? 'board-list__tag-filter-item--active' : ''}`}
+                onClick={() => setSelectedTag(tag)}
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="shop-board__toolbar">
+          <p className="shop-board__summary">마일리지로 구매할 수 있는 아이템입니다.</p>
+        </div>
+        <div className="board-list__divider" />
+
+        {loading && <div className="board-list__status">상품을 불러오는 중...</div>}
+        {!loading && displayPosts.length === 0 && (
+          <div className="board-list__status">등록된 상품이 없습니다.</div>
+        )}
+
+        {!loading && displayPosts.length > 0 && (
+          <>
+            <div className="shop-board__grid">
+              {displayPosts.map((post) => (
+                <Link
+                  key={post.id}
+                  to={`/board/${boardSlug}/${post.id}`}
+                  className="shop-board__card"
+                >
+                  <div className="shop-board__image-wrap">
+                    {thumbnails[post.id] ? (
+                      <img src={thumbnails[post.id] || ''} alt={post.title} className="shop-board__image" />
+                    ) : (
+                      <div className="shop-board__image-placeholder" />
+                    )}
+                    {post.tag?.tagName && <span className="shop-board__tag">{post.tag.tagName}</span>}
+                  </div>
+                  <div className="shop-board__info">
+                    <p className="shop-board__name">{post.title}</p>
+                    <span className="shop-board__price">
+                      {(post.itemPrice ?? 0).toLocaleString()} NC
+                    </span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+
+            {totalPages > 1 && (
+              <div className="board-list__pagination">
+                <button className="board-list__page-btn" onClick={() => handlePageChange(0)} disabled={currentPage === 0}>«</button>
+                <button className="board-list__page-btn" onClick={() => handlePageChange(Math.max(0, currentPage - 1))} disabled={currentPage === 0}>‹</button>
+                {renderPageNumbers().map((page) => (
+                  <button key={page} className={`board-list__page-num ${page === currentPage ? 'board-list__page-num--active' : ''}`} onClick={() => handlePageChange(page)}>{page + 1}</button>
+                ))}
+                <button className="board-list__page-btn" onClick={() => handlePageChange(Math.min(totalPages - 1, currentPage + 1))} disabled={currentPage >= totalPages - 1}>›</button>
+                <button className="board-list__page-btn" onClick={() => handlePageChange(totalPages - 1)} disabled={currentPage >= totalPages - 1}>»</button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </Layout>
+  );
+};
+
+export default ShopBoard;

--- a/NimdaConFrontEnd/src/domains/Board/ShopBoard/index.tsx
+++ b/NimdaConFrontEnd/src/domains/Board/ShopBoard/index.tsx
@@ -15,6 +15,12 @@ const PAGE_SIZE = 12;
 
 const getFirstImageAttachmentId = (board: Board): number | null => {
   if (!board.attachments || board.attachments.length === 0) return null;
+  if (
+    board.thumbnailAttachmentId &&
+    board.attachments.some((attachment) => attachment.id === board.thumbnailAttachmentId)
+  ) {
+    return board.thumbnailAttachmentId;
+  }
   for (const attachment of board.attachments) {
     const ext = attachment.originFilename?.split('.').pop()?.toLowerCase() || '';
     if (!attachment.originFilename || IMAGE_EXTENSIONS.includes(ext)) return attachment.id;
@@ -179,6 +185,12 @@ const ShopBoard: React.FC<ShopBoardProps> = ({ boardSlug }) => {
                   <div className="shop-board__image-wrap">
                     {thumbnails[post.id] ? (
                       <img src={thumbnails[post.id] || ''} alt={post.title} className="shop-board__image" />
+                    ) : post.itemType === 'BADGE' && post.profileDecoration ? (
+                      <img
+                        src={post.profileDecoration.src}
+                        alt={post.profileDecoration.label}
+                        className="shop-board__image"
+                      />
                     ) : (
                       <div className="shop-board__image-placeholder" />
                     )}

--- a/NimdaConFrontEnd/src/domains/Board/types.ts
+++ b/NimdaConFrontEnd/src/domains/Board/types.ts
@@ -23,6 +23,7 @@ export interface Category {
   sortOrder: number;
   postCount: number;
   redirectUrl?: string | null;  // 바로가기 URL (외부 링크, null이면 일반 게시판)
+  shopEnabled?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -67,6 +68,7 @@ export interface Board {
   tag?: { id: number; tagName: string } | null; // Tag 엔티티 참조
   filename?: string | null;
   filepath?: string | null;
+  itemPrice?: number | null;
   /** S3+Attachment 연동 시 상세 조회에 포함 */
   attachments?: BoardAttachmentMeta[];
   createdAt: string;
@@ -123,6 +125,7 @@ export interface BoardWriteRequest {
    */
   attachmentIds?: number[];
   pinned?: boolean; // 게시글 고정 여부 (관리자만 설정 가능)
+  itemPrice?: number | null;
 }
 
 /**

--- a/NimdaConFrontEnd/src/domains/Board/types.ts
+++ b/NimdaConFrontEnd/src/domains/Board/types.ts
@@ -69,6 +69,14 @@ export interface Board {
   filename?: string | null;
   filepath?: string | null;
   itemPrice?: number | null;
+  itemType?: 'GENERAL' | 'BADGE' | string | null;
+  profileDecoration?: {
+    id: number;
+    key: string;
+    label: string;
+    src: string;
+  } | null;
+  thumbnailAttachmentId?: number | null;
   /** S3+Attachment 연동 시 상세 조회에 포함 */
   attachments?: BoardAttachmentMeta[];
   createdAt: string;
@@ -126,6 +134,9 @@ export interface BoardWriteRequest {
   attachmentIds?: number[];
   pinned?: boolean; // 게시글 고정 여부 (관리자만 설정 가능)
   itemPrice?: number | null;
+  itemType?: 'GENERAL' | 'BADGE';
+  profileDecorationId?: number | null;
+  thumbnailAttachmentId?: number | null;
 }
 
 /**

--- a/NimdaConFrontEnd/src/domains/User/MyPage/Point/Components/Profile/ProfileHeader.tsx
+++ b/NimdaConFrontEnd/src/domains/User/MyPage/Point/Components/Profile/ProfileHeader.tsx
@@ -12,6 +12,7 @@ import {
   setProfileDecorationOptions,
 } from "@/constants/profileDecorations";
 import {
+  getMyProfileDecorationsAPI,
   getProfileDecorationsAPI,
   type ProfileDecorationOption,
 } from "@/api/profileDecorations";
@@ -61,12 +62,21 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
     if (!showDecorationModal) return;
 
     const loadDecorations = async () => {
-      const result = await getProfileDecorationsAPI();
+      const [result, ownedResult] = await Promise.all([
+        getProfileDecorationsAPI(),
+        getMyProfileDecorationsAPI(),
+      ]);
       if (result.success && result.decorations.length > 0) {
         const roles = new Set<string>(userInfo?.roles ?? []);
+        const ownedKeys = new Set(
+          ownedResult.success
+            ? ownedResult.decorations.map((decoration) => decoration.key)
+            : []
+        );
         const availableDecorations = result.decorations.filter(
           (decoration) =>
-            !decoration.requiredRole || roles.has(decoration.requiredRole)
+            (!decoration.requiredRole || roles.has(decoration.requiredRole)) &&
+            (!decoration.purchaseRequired || ownedKeys.has(decoration.key))
         );
         setDecorationOptions(availableDecorations);
         setProfileDecorationOptions(availableDecorations);

--- a/NimdaConFrontEnd/src/domains/admin/sections/CategoryManagement.jsx
+++ b/NimdaConFrontEnd/src/domains/admin/sections/CategoryManagement.jsx
@@ -420,6 +420,48 @@ const CategoryManagement = ({
                 </div>
               </div>
 
+              <div className="admin__catorder-form-row">
+                <label className="admin__catorder-form-label">마일리지 구매</label>
+                <div className="admin__catorder-form-field">
+                  <label className="admin__catorder-checkbox-label">
+                    <input
+                      type="checkbox"
+                      checked={Boolean(selectedCategoryData.shopEnabled)}
+                      onChange={async (event) => {
+                        if (!selectedCategoryId) return;
+                        setSavingTags(true);
+                        try {
+                          const result = await updateCategoryAPI(selectedCategoryId, {
+                            name: selectedCategoryData.name,
+                            slug: selectedCategoryData.slug,
+                            parentId: selectedCategoryData.parentId,
+                            sortOrder: selectedCategoryData.sortOrder,
+                            isActive: selectedCategoryData.isActive,
+                            redirectUrl: selectedCategoryData.redirectUrl || null,
+                            shopEnabled: event.target.checked,
+                          });
+                          if (result.success) {
+                            await loadCategories();
+                          } else {
+                            alert(result.message || '마일리지 구매 화면 설정에 실패했습니다.');
+                          }
+                        } catch (error) {
+                          console.error('마일리지 구매 화면 저장 오류:', error);
+                          alert('마일리지 구매 화면 저장 중 오류가 발생했습니다.');
+                        } finally {
+                          setSavingTags(false);
+                        }
+                      }}
+                      disabled={savingTags}
+                    />
+                    <span>이 카테고리를 아이템 구매 화면으로 보여줍니다.</span>
+                  </label>
+                  <p style={{ marginTop: '4px', fontSize: '11px', color: '#999', fontFamily: 'Pretendard, sans-serif' }}>
+                    켜면 게시글 제목은 상품명, 태그는 상품 종류, 첨부 이미지는 상품 이미지, 가격은 작성/수정 화면에서 입력한 NC로 표시됩니다.
+                  </p>
+                </div>
+              </div>
+
               {/* 카테고리 옆에 글 개수 표시 */}
               <div className="admin__catorder-form-row">
                 <label className="admin__catorder-form-label"></label>


### PR DESCRIPTION
 ## 작업 내용

  - 포인트 사용 도메인 분리
    - 게시글 구매 로직을 `point/usage` 패키지로 분리
    - 구매 검증, 포인트 차감, 예외 처리 위치를 서비스로 이동
    - 구매 응답 DTO 추가

  - 마일리지 상점 배지 상품 기능 추가
    - 상품 타입 `GENERAL`, `BADGE` 추가
    - 배지 상품 등록 시 지급할 프로필 배지 연결
    - 구매 성공 시 사용자별 배지 소유권 지급
    - 구매한 배지만 마이페이지에서 장착 가능하도록 제한
    - 중복 보유 배지 구매 차단

  - 마일리지 상점 썸네일 지정 기능 추가
    - 상품 게시글에 `thumbnailAttachmentId` 추가
    - 첨부 이미지 클릭으로 썸네일 지정/해제 가능
    - 명시 지정이 없으면 가장 작은 ID의 이미지로 자동 지정
    - 상점 상품은 이미지 첨부 없이는 저장 불가

  - 관리자 권한 보강
    - 마일리지 상점 상품 등록/수정은 `ROLE_ADMIN`만 가능
    - 부모 상점 카테고리까지 권한 검증 적용

  - 프론트 반영
    - 상품 작성 화면에 상품 타입, 지급 배지, 썸네일 선택 UI 추가
    - 상점 목록/상세에서 배지 이미지 및 지정 썸네일 표시
    - 마이페이지 배지 선택 시 구매 필요 배지는 보유자에게만 노출

  ## DB 변경

  - `V26__Add_badge_shop_purchase.sql`
    - 배지 구매 필요 여부 컬럼 추가
    - 상품 타입 및 배지 연결 컬럼 추가
    - 사용자별 보유 배지 테이블 추가

  - `V27__Add_board_thumbnail_attachment.sql`
    - 게시글 썸네일 첨부 ID 컬럼 추가
