### PR TITLE
feat: 마일리지 구매 탭 복구

### DIFF
--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/CategoryCreateDTO.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/CategoryCreateDTO.java
@@ -68,4 +68,10 @@ public class CategoryCreateDTO {
      */
     @Size(max = 500, message = "URL은 500자를 초과할 수 없습니다")
     private String redirectUrl;
+
+    /**
+     * 마일리지 상점 카테고리 여부
+     * - true이면 상품 등록/구매 화면으로 동작
+     */
+    private Boolean shopEnabled;
 }

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/CategoryResponseDTO.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/CategoryResponseDTO.java
@@ -29,6 +29,7 @@ public class CategoryResponseDTO {
     private Integer sortOrder;
     private Integer postCount;
     private String redirectUrl;  // 바로가기 URL (외부 링크, null이면 일반 게시판)
+    private Boolean shopEnabled;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -53,6 +54,7 @@ public class CategoryResponseDTO {
                 .sortOrder(category.getSortOrder())
                 .postCount(category.getPostCount())
                 .redirectUrl(category.getRedirectUrl())
+                .shopEnabled(category.getShopEnabled())
                 .createdAt(category.getCreatedAt())
                 .updatedAt(category.getUpdatedAt())
                 .build();

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/CategoryUpdateDTO.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/dto/CategoryUpdateDTO.java
@@ -67,4 +67,10 @@ public class CategoryUpdateDTO {
      */
     @Size(max = 500, message = "URL은 500자를 초과할 수 없습니다")
     private String redirectUrl;
+
+    /**
+     * 마일리지 상점 카테고리 여부
+     * - null이면 기존 값 유지
+     */
+    private Boolean shopEnabled;
 }

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/entity/Category.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/entity/Category.java
@@ -82,5 +82,6 @@ public class Category extends BaseTimeEntity {
     private String redirectUrl;
 
     @Column(name = "shop_enabled", nullable = false)
-    private Boolean shopEnabled;
+    @Builder.Default
+    private Boolean shopEnabled = false;
 }

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/service/CategoryService.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/domain/board/service/CategoryService.java
@@ -118,6 +118,7 @@ public class CategoryService {
                 .isActive(createDTO.getIsActive() != null ? createDTO.getIsActive() : true)
                 .postCount(0)
                 .redirectUrl(createDTO.getRedirectUrl() != null && !createDTO.getRedirectUrl().isBlank() ? createDTO.getRedirectUrl().trim() : null)
+                .shopEnabled(createDTO.getShopEnabled() != null ? createDTO.getShopEnabled() : false)
                 .build();
 
         // 4. 저장 및 반환
@@ -184,6 +185,9 @@ public class CategoryService {
         if (updateDTO.getRedirectUrl() != null) {
             // 빈 문자열이면 null로 설정 (URL 제거), 아니면 트림 후 저장
             category.setRedirectUrl(updateDTO.getRedirectUrl().isBlank() ? null : updateDTO.getRedirectUrl().trim());
+        }
+        if (updateDTO.getShopEnabled() != null) {
+            category.setShopEnabled(updateDTO.getShopEnabled());
         }
 
         // 5. 저장 및 반환

--- a/NimdaConBackEnd/backend-spring/src/main/resources/db/migration/V25__Add_badge_shop_purchase.sql
+++ b/NimdaConBackEnd/backend-spring/src/main/resources/db/migration/V25__Add_badge_shop_purchase.sql
@@ -1,15 +1,64 @@
-ALTER TABLE profile_decorations
-    ADD COLUMN purchase_required BOOLEAN NOT NULL DEFAULT FALSE;
+SET @sql := (
+    SELECT IF(
+        COUNT(*) = 0,
+        'ALTER TABLE profile_decorations ADD COLUMN purchase_required BOOLEAN NOT NULL DEFAULT FALSE',
+        'SELECT 1'
+    )
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'profile_decorations'
+      AND column_name = 'purchase_required'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
-ALTER TABLE board
-    ADD COLUMN item_type VARCHAR(30) NOT NULL DEFAULT 'GENERAL',
-    ADD COLUMN profile_decoration_id BIGINT NULL;
+SET @sql := (
+    SELECT IF(
+        COUNT(*) = 0,
+        'ALTER TABLE board ADD COLUMN item_type VARCHAR(30) NOT NULL DEFAULT ''GENERAL''',
+        'SELECT 1'
+    )
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'board'
+      AND column_name = 'item_type'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
-ALTER TABLE board
-    ADD CONSTRAINT fk_board_profile_decoration
-        FOREIGN KEY (profile_decoration_id) REFERENCES profile_decorations(id);
+SET @sql := (
+    SELECT IF(
+        COUNT(*) = 0,
+        'ALTER TABLE board ADD COLUMN profile_decoration_id BIGINT NULL',
+        'SELECT 1'
+    )
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'board'
+      AND column_name = 'profile_decoration_id'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
-CREATE TABLE user_profile_decorations (
+SET @sql := (
+    SELECT IF(
+        COUNT(*) = 0,
+        'ALTER TABLE board ADD CONSTRAINT fk_board_profile_decoration FOREIGN KEY (profile_decoration_id) REFERENCES profile_decorations(id)',
+        'SELECT 1'
+    )
+    FROM information_schema.table_constraints
+    WHERE table_schema = DATABASE()
+      AND table_name = 'board'
+      AND constraint_name = 'fk_board_profile_decoration'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+CREATE TABLE IF NOT EXISTS user_profile_decorations (
     id BIGINT NOT NULL AUTO_INCREMENT,
     user_id BIGINT NOT NULL,
     profile_decoration_id BIGINT NOT NULL,

--- a/NimdaConBackEnd/backend-spring/src/main/resources/db/migration/V26__Add_board_thumbnail_attachment.sql
+++ b/NimdaConBackEnd/backend-spring/src/main/resources/db/migration/V26__Add_board_thumbnail_attachment.sql
@@ -1,7 +1,44 @@
-ALTER TABLE board
-    ADD COLUMN thumbnail_attachment_id BIGINT NULL;
+SET @sql := (
+    SELECT IF(
+        COUNT(*) = 0,
+        'ALTER TABLE board ADD COLUMN thumbnail_attachment_id BIGINT NULL',
+        'SELECT 1'
+    )
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'board'
+      AND column_name = 'thumbnail_attachment_id'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
-ALTER TABLE category
-    ADD COLUMN shop_enabled BOOLEAN DEFAULT false;
+SET @sql := (
+    SELECT IF(
+        COUNT(*) = 0,
+        'ALTER TABLE category ADD COLUMN shop_enabled BOOLEAN NOT NULL DEFAULT FALSE',
+        'SELECT 1'
+    )
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'category'
+      AND column_name = 'shop_enabled'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
-ALTER TABLE board ADD COLUMN item_price INT DEFAULT 0 NOT NULL;
+SET @sql := (
+    SELECT IF(
+        COUNT(*) = 0,
+        'ALTER TABLE board ADD COLUMN item_price BIGINT NOT NULL DEFAULT 0',
+        'SELECT 1'
+    )
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'board'
+      AND column_name = 'item_price'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/NimdaConFrontEnd/src/Router.tsx
+++ b/NimdaConFrontEnd/src/Router.tsx
@@ -18,7 +18,7 @@ import ProtectedRoute from "@/components/ProtectedRoute";
 import ForbiddenPage from "@/domains/Error/403";
 
 import ContestHome from "@/domains/Contest/Home";
-import BoardListPage from "@/domains/Board/BoardList";
+import BoardRoutePage from "@/domains/Board/BoardRoute";
 import BoardDetailPage from "@/domains/Board/BoardDetail";
 import BoardWritePage from "@/domains/Board/BoardWrite";
 import BoardEditPage from "@/domains/Board/BoardEdit";
@@ -48,7 +48,7 @@ const Router = () => {
         <Route path="/user/:nickname" element={<UserProfilePage />} />
         <Route path="/board/picture-board" element={<PhotoGalleryBoard boardSlug="picture-board" boardTitle="사진첩" />} />
         <Route path="/board/banner" element={<PhotoGalleryBoard boardSlug="banner" boardTitle="배너" adminOnlyWrite={true} />} />
-        <Route path="/board/:boardType" element={<BoardListPage />} />
+        <Route path="/board/:boardType" element={<BoardRoutePage />} />
         <Route path="/board/:boardType/:id" element={<BoardDetailPage />} />
 
         {/* 로그인 필수 경로 */}

--- a/NimdaConFrontEnd/src/api/category.ts
+++ b/NimdaConFrontEnd/src/api/category.ts
@@ -162,6 +162,7 @@ export interface CategoryCreateRequest {
   parentId?: number | null;
   sortOrder?: number | null;
   isActive?: boolean | null;
+  shopEnabled?: boolean | null;
 }
 
 /**
@@ -173,6 +174,7 @@ export interface CategoryUpdateRequest {
   parentId?: number | null;
   sortOrder?: number | null;
   isActive?: boolean | null;
+  shopEnabled?: boolean | null;
 }
 
 /**

--- a/NimdaConFrontEnd/src/domains/Board/BoardDetail/BoardDetail.css
+++ b/NimdaConFrontEnd/src/domains/Board/BoardDetail/BoardDetail.css
@@ -491,3 +491,118 @@
   color: var(--color-gray-500);
   font-size: 14px;
 }
+
+.board-detail__shop {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.board-detail__shop-top {
+  display: grid;
+  grid-template-columns: minmax(280px, 420px) minmax(0, 1fr);
+  gap: 36px;
+  align-items: start;
+  margin-top: 24px;
+}
+
+.board-detail__shop-image-wrap {
+  overflow: hidden;
+  border: 1px solid #dedede;
+  border-radius: 8px;
+  background: #eeeeee;
+  aspect-ratio: 1 / 1;
+}
+
+.board-detail__shop-image,
+.board-detail__shop-image-placeholder {
+  width: 100%;
+  height: 100%;
+}
+
+.board-detail__shop-image {
+  object-fit: cover;
+}
+
+.board-detail__shop-image-placeholder {
+  background:
+    linear-gradient(135deg, rgba(217, 115, 153, 0.16), rgba(75, 162, 233, 0.12)),
+    #eeeeee;
+}
+
+.board-detail__shop-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+
+.board-detail__shop-tag {
+  align-self: flex-start;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: #0c0c0c;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.board-detail__shop-title {
+  margin: 0;
+  color: #0c0c0c;
+  font-size: 28px;
+  font-weight: 800;
+  line-height: 1.3;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+.board-detail__shop-price {
+  padding: 18px 0;
+  border-top: 1px solid #dedede;
+  border-bottom: 1px solid #dedede;
+  color: #d97399;
+  font-size: 30px;
+  font-weight: 900;
+  line-height: 1.1;
+}
+
+.board-detail__shop-buy {
+  width: 100%;
+  height: 48px;
+  border: 0;
+  border-radius: 8px;
+  background: #d97399;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.board-detail__shop-buy:hover:not(:disabled) {
+  background: #c45d84;
+}
+
+.board-detail__shop-buy:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.board-detail__shop-description {
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid #dedede;
+}
+
+.board-detail__shop-description h2 {
+  margin: 0 0 16px;
+  color: #0c0c0c;
+  font-size: 18px;
+  font-weight: 800;
+}
+
+@media (max-width: 820px) {
+  .board-detail__shop-top {
+    grid-template-columns: 1fr;
+  }
+}

--- a/NimdaConFrontEnd/src/domains/Board/BoardDetail/index.tsx
+++ b/NimdaConFrontEnd/src/domains/Board/BoardDetail/index.tsx
@@ -4,12 +4,13 @@ import DOMPurify, { type Config as DOMPurifyConfig } from 'dompurify';
 import { MessageBox } from '@/components/icons/MessageBox';
 import { VerticalDots } from '@/components/icons/VerticalDots';
 import Layout from '@/components/Layout';
-import { openAttachmentDownloadInNewTab } from '@/api/attachments';
+import { getAttachmentPresignedUrl, openAttachmentDownloadInNewTab } from '@/api/attachments';
 import {
   getBoardDetailAPI,
   deleteBoardAPI,
   getFileDownloadURL,
   getBoardLikeStatusAPI,
+  purchaseBoardItemAPI,
 } from '@/api/board';
 import { getAllCategoriesAPI } from '@/api/category';
 import { hasRole, isAdmin, getCurrentNickname } from '@/utils/jwt';
@@ -22,6 +23,22 @@ import { highlightCodeBlocks } from '@/utils/codeHighlight';
 import './BoardDetail.css';
 
 const MAX_VIEWER_FONT_SIZE_PX = 24;
+const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg'];
+
+const getFirstImageAttachmentId = (board: Board): number | null => {
+  if (!board.attachments || board.attachments.length === 0) return null;
+  if (
+    board.thumbnailAttachmentId &&
+    board.attachments.some((attachment) => attachment.id === board.thumbnailAttachmentId)
+  ) {
+    return board.thumbnailAttachmentId;
+  }
+  for (const attachment of board.attachments) {
+    const ext = attachment.originFilename?.split('.').pop()?.toLowerCase() || '';
+    if (!attachment.originFilename || IMAGE_EXTENSIONS.includes(ext)) return attachment.id;
+  }
+  return null;
+};
 
 const normalizeViewerFontSize = (size: string, fallbackPx = 14) => {
   const match = size
@@ -149,6 +166,8 @@ function BoardDetailPage() {
   const [isLiked, setIsLiked] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [showAttachments, setShowAttachments] = useState(false);
+  const [shopImageUrl, setShopImageUrl] = useState<string | null>(null);
+  const [isPurchasing, setIsPurchasing] = useState(false);
   const normalizedViewerContent = sanitizeViewerContent(board?.content ?? '');
   const bodyRef = useRef<HTMLDivElement>(null);
 
@@ -162,6 +181,34 @@ function BoardDetailPage() {
       highlightCodeBlocks(body);
     }
   }, [normalizedViewerContent]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadShopImage = async () => {
+      if (!board?.category?.shopEnabled) {
+        setShopImageUrl(null);
+        return;
+      }
+
+      const attachmentId = getFirstImageAttachmentId(board);
+      if (!attachmentId) {
+        setShopImageUrl(null);
+        return;
+      }
+
+      try {
+        const url = await getAttachmentPresignedUrl(attachmentId);
+        if (!cancelled) setShopImageUrl(url);
+      } catch {
+        if (!cancelled) setShopImageUrl(null);
+      }
+    };
+
+    loadShopImage();
+    return () => {
+      cancelled = true;
+    };
+  }, [board]);
 
   const fetchBoard = async (boardId: number) => {
     try {

--- a/NimdaConFrontEnd/src/domains/Board/BoardRoute/index.tsx
+++ b/NimdaConFrontEnd/src/domains/Board/BoardRoute/index.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import BoardListPage from '@/domains/Board/BoardList';
+import ShopBoard from '@/domains/Board/ShopBoard';
+import { getCategoryBySlugAPI } from '@/api/category';
+import type { Category } from '@/domains/Board/types';
+
+function BoardRoutePage() {
+  const { boardType } = useParams<{ boardType: string }>();
+  const slug = boardType?.toLowerCase() || 'news';
+  const [category, setCategory] = useState<Category | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getCategoryBySlugAPI(slug)
+      .then((nextCategory) => {
+        if (!cancelled) setCategory(nextCategory);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  if (loading) return <BoardListPage slug={slug} />;
+  if (category?.shopEnabled) return <ShopBoard boardSlug={slug} />;
+  return <BoardListPage slug={slug} />;
+}
+
+export default BoardRoutePage;

--- a/NimdaConFrontEnd/src/domains/Board/ShopBoard/ShopBoard.css
+++ b/NimdaConFrontEnd/src/domains/Board/ShopBoard/ShopBoard.css
@@ -1,0 +1,126 @@
+.shop-board {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.shop-board__toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+  margin: 18px 0 8px;
+}
+
+.shop-board__summary {
+  margin: 0;
+  color: #737373;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.shop-board__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 22px;
+}
+
+.shop-board__card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid #dedede;
+  border-radius: 8px;
+  background: #fff;
+  transition: transform 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.shop-board__card:hover {
+  transform: translateY(-2px);
+  border-color: #d97399;
+  box-shadow: 0 10px 26px rgba(12, 12, 12, 0.08);
+}
+
+.shop-board__image-wrap {
+  position: relative;
+  background: #eeeeee;
+  aspect-ratio: 1 / 1;
+}
+
+.shop-board__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.shop-board__image-placeholder {
+  width: 100%;
+  height: 100%;
+  background:
+    linear-gradient(135deg, rgba(217, 115, 153, 0.16), rgba(75, 162, 233, 0.12)),
+    #eeeeee;
+}
+
+.shop-board__tag {
+  position: absolute;
+  left: 10px;
+  top: 10px;
+  max-width: calc(100% - 20px);
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(12, 12, 12, 0.78);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.shop-board__info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+}
+
+.shop-board__name {
+  margin: 0;
+  min-height: 42px;
+  color: #0c0c0c;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.shop-board__price {
+  color: #d97399;
+  font-size: 16px;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+@media (max-width: 900px) {
+  .shop-board__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .shop-board__toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .shop-board__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/NimdaConFrontEnd/src/domains/admin/sections/CategoryManagement.jsx
+++ b/NimdaConFrontEnd/src/domains/admin/sections/CategoryManagement.jsx
@@ -420,6 +420,48 @@ const CategoryManagement = ({
                 </div>
               </div>
 
+              <div className="admin__catorder-form-row">
+                <label className="admin__catorder-form-label">마일리지 구매</label>
+                <div className="admin__catorder-form-field">
+                  <label className="admin__catorder-checkbox-label">
+                    <input
+                      type="checkbox"
+                      checked={Boolean(selectedCategoryData.shopEnabled)}
+                      onChange={async (event) => {
+                        if (!selectedCategoryId) return;
+                        setSavingTags(true);
+                        try {
+                          const result = await updateCategoryAPI(selectedCategoryId, {
+                            name: selectedCategoryData.name,
+                            slug: selectedCategoryData.slug,
+                            parentId: selectedCategoryData.parentId,
+                            sortOrder: selectedCategoryData.sortOrder,
+                            isActive: selectedCategoryData.isActive,
+                            redirectUrl: selectedCategoryData.redirectUrl || null,
+                            shopEnabled: event.target.checked,
+                          });
+                          if (result.success) {
+                            await loadCategories();
+                          } else {
+                            alert(result.message || '마일리지 구매 화면 설정에 실패했습니다.');
+                          }
+                        } catch (error) {
+                          console.error('마일리지 구매 화면 저장 오류:', error);
+                          alert('마일리지 구매 화면 저장 중 오류가 발생했습니다.');
+                        } finally {
+                          setSavingTags(false);
+                        }
+                      }}
+                      disabled={savingTags}
+                    />
+                    <span>이 카테고리를 아이템 구매 화면으로 보여줍니다.</span>
+                  </label>
+                  <p style={{ marginTop: '4px', fontSize: '11px', color: '#999', fontFamily: 'Pretendard, sans-serif' }}>
+                    켜면 게시글 제목은 상품명, 태그는 상품 종류, 첨부 이미지는 상품 이미지, 가격은 작성/수정 화면에서 입력한 NC로 표시됩니다.
+                  </p>
+                </div>
+              </div>
+
               {/* 카테고리 옆에 글 개수 표시 */}
               <div className="admin__catorder-form-row">
                 <label className="admin__catorder-form-label"></label>


### PR DESCRIPTION
  ## 변경사항

  - 마일리지 구매 탭 라우팅 복구
  - shopEnabled 카테고리 설정 추가
  - 관리자 카테고리 관리 화면에서 마일리지 구매 탭 여부 설정 가능
  - 마일리지 상품 상세 페이지 표시 로직 복구
  - 상품 이미지 및 구매 UI 스타일 추가
  - 관련 Flyway 마이그레이션을 재실행 가능하도록 보완

  ## 테스트

  - 프론트엔드 빌드 확인
  - 백엔드 패키징 확인
  - 마일리지 구매 탭 게시글 상세 진입 확인