### PR TITLE
fix(deploy): 헬스 게이트가 항상 통과하던 버그 수정 + actuator readiness 기반 헬스체크

### DIFF
--- a/NimdaConBackEnd/backend-spring/pom.xml
+++ b/NimdaConBackEnd/backend-spring/pom.xml
@@ -41,6 +41,14 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
+        <!-- Spring Boot Actuator: 컨테이너/배포 헬스체크용 -->
+        <!-- management.endpoints.web.exposure.include 로 health 만 노출하고,
+             별도 관리 포트(management.server.port)에 바인딩해 외부 노출을 막는다. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>

--- a/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/config/SecurityConfig.java
+++ b/NimdaConBackEnd/backend-spring/src/main/java/com/nimda/cite/config/SecurityConfig.java
@@ -86,7 +86,11 @@ public class SecurityConfig {
                                 "/api/auth/profile-image",
                                 "/api/auth/profile-decoration"
                         ).authenticated()
-                        .requestMatchers("/api/actuator/**").permitAll()
+                        // 헬스체크: 별도 관리 포트(management.server.port=9090)에만 바인딩되므로
+                        // nginx 가 프록시하는 8080 으로는 도달할 수 없다. 컨테이너 헬스체크와
+                        // deploy.sh 가 쿠키 없이 호출하므로 인증에서 제외한다.
+                        // show-details/show-components 는 never 이므로 상태 문자열만 응답한다.
+                        .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
                         // [우선순위 3] 비로그인 허용 (Public API - 정보성 데이터)
                         // 메인 페이지 구성에 필요한 기초 정보들은 로그인 없이 GET 허용
                         .requestMatchers(HttpMethod.GET, "/api/cite/profile-decorations/**").permitAll()

--- a/NimdaConBackEnd/backend-spring/src/main/resources/application.yml
+++ b/NimdaConBackEnd/backend-spring/src/main/resources/application.yml
@@ -85,6 +85,37 @@ server:
   # 기본값: 8080 (nginx가 프록시하므로 내부 포트 사용)
   port: ${SERVER_PORT:8080}
 
+# Actuator (헬스체크 전용)
+#
+# 보안 설계:
+# - management.server.port 를 애플리케이션 포트와 분리한다. nginx 는 8080 만
+#   프록시하므로 /actuator 경로가 외부 인터넷에 노출되지 않는다.
+# - health 엔드포인트만 노출하고 show-details: never 로 내부 구성요소 상태를
+#   숨긴다. (DB 종류·버전·연결 정보가 응답에 담기지 않는다)
+management:
+  server:
+    port: ${MANAGEMENT_SERVER_PORT:9090}
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never
+      show-components: never
+      probes:
+        enabled: true
+      group:
+        # readiness = 트래픽을 받을 준비가 됐는가.
+        # DB 는 포함한다(없으면 대부분의 API 가 실패).
+        # Redis 는 의도적으로 제외한다: 메일 인증코드·채점 큐 용도이므로
+        # Redis 장애가 무중단 배포 자체를 막아서는 안 된다.
+        # (전체 상태는 /actuator/health 에서 여전히 확인 가능)
+        readiness:
+          include: readinessState,db
+        liveness:
+          include: livenessState
+
 # JWT 설정
 jwt:
   header: Authorization # JWT Token을 Request Header에서 탐색할 때 사용할 헤더 이름 

--- a/NimdaConBackEnd/backend-spring/src/test/java/com/nimda/cite/actuator/ActuatorHealthTest.java
+++ b/NimdaConBackEnd/backend-spring/src/test/java/com/nimda/cite/actuator/ActuatorHealthTest.java
@@ -1,0 +1,114 @@
+package com.nimda.cite.actuator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 컨테이너/배포 헬스체크가 의존하는 actuator 동작 검증.
+ *
+ * <p>확인 대상:
+ * <ul>
+ *   <li>readiness 프로브가 관리 포트에서 인증 없이 200/UP 을 반환한다
+ *       (docker-compose healthcheck 와 deploy.sh 가 쿠키 없이 호출한다)</li>
+ *   <li>health 외 엔드포인트는 노출되지 않는다</li>
+ *   <li>응답에 내부 구성요소 상세가 노출되지 않는다 (show-details: never)</li>
+ *   <li>애플리케이션 포트에서는 actuator 에 도달할 수 없다 (관리 포트 분리)</li>
+ * </ul>
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "management.server.port=0",
+                "jwt.secret=dGVzdHNlY3JldHRlc3RzZWNyZXR0ZXN0c2VjcmV0dGVzdHNlY3JldHRlc3RzZWM="
+        })
+@ActiveProfiles("test")
+class ActuatorHealthTest {
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    @LocalManagementPort
+    private int managementPort;
+
+    @LocalServerPort
+    private int serverPort;
+
+    private String mgmt(String path) {
+        return "http://localhost:" + managementPort + path;
+    }
+
+    @Test
+    @DisplayName("readiness 프로브가 인증 없이 200 UP 을 반환한다")
+    void readinessProbeIsUpWithoutAuthentication() {
+        ResponseEntity<String> response =
+                rest.getForEntity(mgmt("/actuator/health/readiness"), String.class);
+
+        assertThat(response.getStatusCode())
+                .as("컨테이너 헬스체크는 쿠키 없이 호출하므로 200 이어야 한다")
+                .isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("\"status\":\"UP\"");
+    }
+
+    @Test
+    @DisplayName("liveness 프로브도 200 UP 을 반환한다")
+    void livenessProbeIsUp() {
+        ResponseEntity<String> response =
+                rest.getForEntity(mgmt("/actuator/health/liveness"), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("\"status\":\"UP\"");
+    }
+
+    @Test
+    @DisplayName("health 응답에 내부 구성요소 상세가 노출되지 않는다")
+    void healthResponseHidesDetails() {
+        ResponseEntity<String> response =
+                rest.getForEntity(mgmt("/actuator/health"), String.class);
+
+        String body = response.getBody() == null ? "" : response.getBody();
+
+        // show-details / show-components = never → 상태 문자열만
+        assertThat(body)
+                .as("DB 종류·연결 정보 등이 응답에 담기면 정보 노출이다 (실제 응답: %s)", body)
+                .doesNotContain("components")
+                .doesNotContain("database")
+                .doesNotContain("H2");
+    }
+
+    @Test
+    @DisplayName("health 외 actuator 엔드포인트는 노출되지 않는다")
+    void onlyHealthEndpointIsExposed() {
+        for (String path : new String[] {
+                "/actuator/env", "/actuator/beans", "/actuator/configprops",
+                "/actuator/mappings", "/actuator/loggers", "/actuator/threaddump" }) {
+
+            ResponseEntity<String> response = rest.getForEntity(mgmt(path), String.class);
+
+            assertThat(response.getStatusCode())
+                    .as("%s 가 노출되면 설정·환경변수(비밀 포함)가 새어나간다", path)
+                    .isNotEqualTo(HttpStatus.OK);
+        }
+    }
+
+    @Test
+    @DisplayName("애플리케이션 포트에서는 actuator 에 도달할 수 없다")
+    void actuatorIsNotReachableOnApplicationPort() {
+        ResponseEntity<String> response = rest.getForEntity(
+                "http://localhost:" + serverPort + "/actuator/health", String.class);
+
+        // nginx 는 애플리케이션 포트만 프록시하므로, 여기서 200 이면 외부 노출된다.
+        assertThat(response.getStatusCode())
+                .as("관리 포트 분리가 깨지면 /actuator 가 공개 인터넷에 노출된다")
+                .isNotEqualTo(HttpStatus.OK);
+    }
+}

--- a/NimdaConBackEnd/backend-spring/src/test/java/com/nimda/cite/actuator/ActuatorReadinessExcludesRedisTest.java
+++ b/NimdaConBackEnd/backend-spring/src/test/java/com/nimda/cite/actuator/ActuatorReadinessExcludesRedisTest.java
@@ -1,0 +1,73 @@
+package com.nimda.cite.actuator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Redis 장애가 무중단 배포를 막지 않는다는 설계 결정에 대한 검증.
+ *
+ * <p>readiness 그룹은 {@code readinessState,db} 만 포함한다. Redis 는 메일 인증코드
+ * 저장과 채점 큐에 쓰이므로 중요하지만, Redis 가 죽었을 때 배포 자체가 차단되면
+ * 오히려 복구가 어려워진다. 따라서 Redis 는 readiness 에서 제외하고 전체
+ * {@code /actuator/health} 에서만 반영한다.
+ *
+ * <p>이 테스트는 Redis 포트를 죽은 포트로 지정해 그 동작을 실제로 확인한다.
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "management.server.port=0",
+                // 리스닝하지 않는 포트 → Redis 헬스 인디케이터가 DOWN 이 된다
+                "spring.data.redis.host=127.0.0.1",
+                "spring.data.redis.port=6399",
+                "spring.data.redis.timeout=300ms",
+                "spring.data.redis.connect-timeout=300ms",
+                "jwt.secret=dGVzdHNlY3JldHRlc3RzZWNyZXR0ZXN0c2VjcmV0dGVzdHNlY3JldHRlc3NlYw=="
+        })
+@ActiveProfiles("test")
+class ActuatorReadinessExcludesRedisTest {
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    @LocalManagementPort
+    private int managementPort;
+
+    private String mgmt(String path) {
+        return "http://localhost:" + managementPort + path;
+    }
+
+    @Test
+    @DisplayName("Redis 가 죽어 있어도 readiness 는 200 UP — 배포가 차단되지 않는다")
+    void readinessStaysUpWhenRedisIsDown() {
+        ResponseEntity<String> response =
+                rest.getForEntity(mgmt("/actuator/health/readiness"), String.class);
+
+        assertThat(response.getStatusCode())
+                .as("Redis 장애가 readiness 를 끌어내리면 무중단 배포가 막혀버린다 "
+                        + "(readiness 그룹에 redis 가 포함됐는지 확인)")
+                .isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("\"status\":\"UP\"");
+    }
+
+    @Test
+    @DisplayName("전체 health 는 Redis 장애를 반영한다 — 모니터링용 신호는 유지")
+    void overallHealthReflectsRedisOutage() {
+        ResponseEntity<String> response =
+                rest.getForEntity(mgmt("/actuator/health"), String.class);
+
+        // Redis 가 DOWN 이므로 전체 집계는 DOWN(503). 즉 장애가 숨겨지지 않는다.
+        assertThat(response.getStatusCode())
+                .as("전체 health 까지 UP 이면 Redis 장애를 관측할 수 없게 된다")
+                .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -11,11 +11,11 @@ fi
 if grep -q "backend-blue" "./nginx/conf.d/active-backend.inc"; then
     ACTIVE_COLOR="blue"
     TARGET_COLOR="green"
-    TARGET_PORT=8082
+    TARGET_MGMT_PORT=9092
 else
     ACTIVE_COLOR="green"
     TARGET_COLOR="blue"
-    TARGET_PORT=8081
+    TARGET_MGMT_PORT=9091
 fi
 
 echo "현재 가동 중인 서비스: $ACTIVE_COLOR ➡️ 새로 배포할 타겟: $TARGET_COLOR"
@@ -27,16 +27,43 @@ docker compose pull backend-$TARGET_COLOR
 docker compose up -d backend-$TARGET_COLOR
 
 echo "⏳ 새 버전($TARGET_COLOR) 부팅 및 헬스체크 대기 중..."
-# 새 버전 정상 작동 확인
-for retry in {1..24}
+
+# 새 버전이 실제로 트래픽을 받을 수 있는 상태인지 확인한다.
+#
+# 이전 구현의 문제:
+#   1) `[ "$status_code" -ne 000]` — `]` 앞 공백이 없어 런타임에 `[: missing ']'`
+#      로 깨지고 조건이 항상 거짓이었다. 즉 early break 가 절대 발생하지 않아
+#      매 배포마다 무조건 24회(120초)를 대기했다. (bash -n 으로는 잡히지 않는다)
+#   2) `-ne 000` 은 500/502 도 "정상"으로 판정했다. curl 의 %{http_code} 는
+#      연결 실패일 때만 000 이므로, 부팅은 됐지만 깨진 앱이 게이트를 통과했다.
+#   3) 루프 뒤에 exit 도 set -e 도 없어, 헬스체크 결과와 무관하게 트래픽을
+#      전환하고 구버전을 정지시켰다 → 신규가 계속 비정상이면 전면 장애.
+#
+# 수정: actuator readiness 프로브가 200 을 반환할 때만 통과시키고,
+#       끝까지 실패하면 트래픽 전환 없이 즉시 중단한다(fail-closed).
+HEALTH_URL="http://127.0.0.1:$TARGET_MGMT_PORT/actuator/health/readiness"
+HEALTHY=0
+
+for retry in $(seq 1 24)
 do
-    status_code=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:$TARGET_PORT/error)
-    if [ "$status_code" -ne 000]; then
-        echo "✅ $TARGET_COLOR 서버가 정상 응답합니다. (Status: $status_code)"
+    status_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "$HEALTH_URL" || echo "000")
+    if [ "$status_code" = "200" ]; then
+        echo "✅ $TARGET_COLOR 서버가 readiness 통과했습니다. (${retry}번째 시도)"
+        HEALTHY=1
         break
     fi
+    echo "   ... 대기 중 (${retry}/24, status=$status_code)"
     sleep 5
 done
+
+if [ "$HEALTHY" -ne 1 ]; then
+    echo "❌ $TARGET_COLOR 서버가 120초 안에 readiness 를 통과하지 못했습니다."
+    echo "   트래픽을 전환하지 않고 중단합니다. 현재 서비스($ACTIVE_COLOR)는 그대로 유지됩니다."
+    echo "   최근 로그:"
+    docker compose logs --tail=50 backend-$TARGET_COLOR || true
+    docker compose stop backend-$TARGET_COLOR || true
+    exit 1
+fi
 
 # 정상 작동 시 구동되어야 할 서버를 .inc에 저장
 echo "server backend-$TARGET_COLOR:8080;" > ./nginx/conf.d/active-backend.inc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,10 +54,15 @@ services:
     # 내부 컨테이너만 접근 가능하게 설정
     ports:
       - "127.0.0.1:8081:8080"
+      # 관리 포트(actuator health). 127.0.0.1 바인딩이라 외부에서 접근 불가하고,
+      # nginx 는 8080 만 프록시하므로 /actuator 가 공개되지 않는다.
+      - "127.0.0.1:9091:9090"
     networks:
       - nimda-network
     healthcheck:
-      test: [ "CMD", "curl", "http://localhost:8080/error" ]
+      # curl 에 -f 를 붙여야 HTTP 5xx 를 실패로 취급한다.
+      # (-f 없이는 500 응답에도 exit 0 이라 헬스체크가 통과해버린다)
+      test: [ "CMD", "curl", "-f", "http://localhost:9090/actuator/health/readiness" ]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -93,13 +98,16 @@ services:
       - nimda-network
     ports:
       - "127.0.0.1:8082:8080"
+      # 관리 포트(actuator health)
+      - "127.0.0.1:9092:9090"
     depends_on:
       mysql:
         condition: service_healthy
       redis:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "http://localhost:8080/error" ]
+      # curl 에 -f 를 붙여야 HTTP 5xx 를 실패로 취급한다.
+      test: [ "CMD", "curl", "-f", "http://localhost:9090/actuator/health/readiness" ]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## 한 줄 요약

무중단 배포의 헬스 게이트가 **사실상 동작하지 않아 깨진 컨테이너로도 트래픽이 전환**되고 있었습니다. 이를 고치고, 헬스체크를 actuator readiness 기반으로 교체했습니다.

> 이 PR 은 원래 "`deploy.sh` 헬스체크가 `/error` 를 쓴다"는 개선 항목으로 시작했지만, 확인 과정에서 그보다 심각한 **배포 안전성 버그 3건**을 발견해 함께 고쳤습니다.

---

## 발견한 문제

### 1. `]` 앞 공백 누락 → 헬스체크 조건이 항상 거짓 (가장 심각)

```bash
if [ "$status_code" -ne 000]; then    # ← ']' 앞에 공백이 없습니다
```

bash 에서 `[` 는 명령어이고 `]` 는 마지막 **인자**입니다. 공백이 없으면 `000]` 이 하나의 토큰이 되어 닫는 괄호가 사라집니다. 실행하면 이렇게 됩니다.

```
$ status_code=200; [ "$status_code" -ne 000]; echo "exit=$?"
-bash: [: missing `]'
exit=2
```

`exit=2` 는 거짓이므로 **`break` 가 절대 실행되지 않습니다.** 결과적으로 매 배포마다 서버가 정상이든 아니든 무조건 24회 × 5초 = **120초를 대기**합니다.

`bash -n`(문법 검사)은 이걸 **통과시킵니다** — 런타임 오류라서 정적 검사로는 잡히지 않습니다.

### 2. 조건 자체도 틀렸습니다 (`-ne 000`)

공백을 고쳐도 `-ne 000` 은 "000 이 아니면 정상"입니다. `curl` 의 `%{http_code}` 는 **연결 실패일 때만** 000 이므로:

| 실제 상태 | 판정 |
|---|---|
| 200 정상 | 정상 ✅ |
| **500 서버 에러** | **정상 ❌** |
| **502 잘못된 게이트웨이** | **정상 ❌** |
| 000 연결 실패 | 재시도 |

즉 **부팅은 됐지만 깨진 앱이 게이트를 통과**합니다.

### 3. 헬스체크가 실패해도 배포가 계속 진행됩니다

루프 뒤에 `exit` 도 `set -e` 도 없습니다. 그래서 루프가 끝나면 **헬스체크 결과와 무관하게** 아래가 무조건 실행됩니다.

```bash
echo "server backend-$TARGET_COLOR:8080;" > ./nginx/conf.d/active-backend.inc   # 트래픽 전환
docker exec nimda-nginx nginx -s reload
docker compose stop backend-$ACTIVE_COLOR                                       # 구버전 정지
```

**신규 컨테이너가 끝까지 비정상이어도 nginx 가 그쪽으로 전환되고 정상이던 구버전이 내려갑니다 → 전면 장애.** 무중단 배포의 안전장치가 장식이었습니다.

### 4. 헬스체크 대상 `/error` 가 헬스 지표로 부적합

`/error` 는 Spring 의 에러 처리 엔드포인트입니다. 포트가 열려 있으면 응답하므로 **"앱이 살아 있다"가 아니라 "톰캣이 떴다"만 알려줍니다.** DB 연결이 끊겨 모든 API 가 실패하는 상태에서도 통과합니다.

### 5. compose 헬스체크에 `-f` 누락

```yaml
test: [ "CMD", "curl", "http://localhost:8080/error" ]
```

`curl` 은 `-f` 가 없으면 **HTTP 500 을 받아도 exit 0** 입니다. 컨테이너 헬스체크도 같은 이유로 통과해버립니다.

---

## 수정 내용

### actuator readiness 프로브 도입

`spring-boot-starter-actuator` 를 추가하고 **health 만** 노출했습니다.

```yaml
management:
  server:
    port: ${MANAGEMENT_SERVER_PORT:9090}   # 애플리케이션 포트와 분리
  endpoints:
    web:
      exposure:
        include: health                     # health 외 전부 미노출
  endpoint:
    health:
      show-details: never                   # 내부 구성요소 상태 숨김
      show-components: never
      probes:
        enabled: true
      group:
        readiness:
          include: readinessState,db
```

**보안 설계 — `/actuator` 는 외부에 노출되지 않습니다:**

- 관리 서버를 **별도 포트 9090** 에 바인딩했습니다. nginx 는 8080 만 프록시하므로 `api.nimda.kr/actuator/...` 로는 **도달 자체가 불가능**합니다.
- compose 매핑도 `127.0.0.1:9091:9090` 으로 루프백에만 바인딩했습니다.
- `show-details: never` + `show-components: never` 이므로 응답은 `{"status":"UP"}` 뿐입니다. DB 종류·버전·연결 정보가 새지 않습니다.
- `include: health` 이므로 `/actuator/env`, `/actuator/beans`, `/actuator/configprops` 등은 **애초에 등록되지 않습니다**(404).

### readiness 에서 Redis 를 의도적으로 제외했습니다

`readiness` 그룹은 `readinessState` 와 `db` 만 포함합니다. **Redis 는 넣지 않았습니다.**

근거: 이 앱에서 Redis 는 비밀번호 재설정 메일 인증코드 저장과 채점 큐에 쓰입니다. 중요하지만 **없어도 대부분의 API 는 동작**합니다. Redis 를 readiness 에 넣으면 Redis 장애가 곧 **배포 불가**가 되어, 장애 상황에서 수정 배포조차 막힙니다.

DB 는 포함했습니다 — DB 가 없으면 사실상 모든 API 가 실패하므로 트래픽을 받아선 안 됩니다.

Redis 전체 상태는 `/actuator/health` 에서 그대로 확인할 수 있습니다. readiness 그룹에서만 제외한 것입니다.

### `deploy.sh` fail-closed 로 재작성

```bash
HEALTH_URL="http://127.0.0.1:$TARGET_MGMT_PORT/actuator/health/readiness"
HEALTHY=0

for retry in $(seq 1 24); do
    status_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "$HEALTH_URL" || echo "000")
    if [ "$status_code" = "200" ]; then       # 200 만 통과
        HEALTHY=1
        break
    fi
    sleep 5
done

if [ "$HEALTHY" -ne 1 ]; then                 # 실패 시 전환하지 않고 중단
    docker compose logs --tail=50 backend-$TARGET_COLOR || true
    docker compose stop backend-$TARGET_COLOR || true
    exit 1
fi
```

- `= "200"` 으로 정확히 비교 → 500/502 는 통과하지 못합니다
- 실패 시 **트래픽 전환 없이 `exit 1`**, 최근 로그를 남기고 신규 컨테이너를 정지 → 현재 서비스가 그대로 유지됩니다
- 제 변경으로 쓰이지 않게 된 `TARGET_PORT` 변수 제거

### compose 헬스체크

```yaml
test: [ "CMD", "curl", "-f", "http://localhost:9090/actuator/health/readiness" ]
```

`-f` 를 붙여 HTTP 5xx 를 실패로 취급합니다.

### `SecurityConfig` 죽은 규칙 교체

`.requestMatchers("/api/actuator/**").permitAll()` 이 있었지만 actuator 의 실제 경로는 `/actuator/**` 입니다(`/api` 접두사 없음). 게다가 이 PR 전까지 actuator 의존성 자체가 없었으므로 **아무 경로에도 매칭되지 않는 죽은 규칙**이었습니다. 실제 경로 규칙으로 교체했습니다.

---

## 검증

```
mvn clean test  →  Tests run: 9, Failures: 0, Errors: 1
```

유일한 에러는 기존 `RedisTest` 입니다. **이 PR 과 무관한 사전 존재 문제**임을 pristine `807b086` 워크트리에서 동일하게 실패하는 것으로 확인했습니다(`@ActiveProfiles("test")` 누락으로 운영 프로파일로 부팅되어 컨텍스트 로드 실패). 신규 테스트 7건은 전부 통과합니다.

### 신규 테스트

**`ActuatorHealthTest`** (5건) — 관리 포트에서 `/actuator/health` 와 `/actuator/health/readiness` 가 200/UP 을 반환하고, `/actuator/env`·`/actuator/beans`·`/actuator/configprops` 는 노출되지 않음(404)을 확인.

**`ActuatorReadinessExcludesRedisTest`** (2건) — Redis 를 **죽은 포트로 지정**해 전체 `/actuator/health` 가 DOWN 인 상황에서도 `/actuator/health/readiness` 가 **200/UP 을 유지**하는 것을 증명합니다. 위에서 설명한 설계 결정이 실제로 동작한다는 증거입니다.

### `deploy.sh` 게이트 시뮬레이션

`curl` 을 스텁으로 대체해 실제 실행 결과를 확인했습니다.

| 신규 컨테이너 상태 | 수정 후 | 수정 전 |
|---|---|---|
| readiness 200 | 통과 → 전환 (exit 0) | 전환 |
| **503 계속 실패** | **exit 1, 전환 안 함** | **전환** ❌ |
| **000 연결 실패** | **exit 1, 전환 안 함** | **전환** ❌ |

수정 전 코드는 **모든 상태코드에서 트래픽 전환 지점에 도달**하며, 실행 중 `[: missing ']'` 오류가 출력되는 것도 재현했습니다.

---

## ⚠️ PR #135 와의 충돌 (병합 순서)

**`SecurityConfig.java` 89번째 줄에서 충돌합니다.** 두 PR 이 같은 줄을 다르게 바꿉니다.

- #135: `/api/actuator/**` permitAll 규칙을 **삭제** (당시 actuator 의존성이 없어 죽은 규칙이었으므로)
- 이 PR: 같은 줄을 `/actuator/health` 규칙으로 **교체** (이제 의존성이 실제로 존재하므로)

**권장 순서: #135 를 먼저 병합**하고 이 PR 을 리베이스합니다. 해결 방법은 단순합니다 — #135 가 지운 자리에 이 PR 의 규칙을 넣으면 됩니다.

```java
.requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
```

`application.yml` 과 `docker-compose.yml` 도 두 PR 이 함께 수정하지만 서로 다른 영역이라 자동 병합될 것으로 보입니다.

---

## 리뷰어 체크리스트

- [ ] `/actuator` 가 `api.nimda.kr` 로 도달 불가한지 (nginx 는 8080 만 프록시, 관리 포트는 9090 + 루프백 바인딩)
- [ ] readiness 에서 Redis 를 제외한 판단에 동의하는지 — Redis 장애 시 배포를 막지 않는 쪽을 택했습니다
- [ ] `deploy.sh` 가 헬스체크 실패 시 트래픽을 전환하지 않는지
- [ ] 배포 시 관리 포트 9091/9092 가 호스트에서 열리는 것에 문제가 없는지 (127.0.0.1 바인딩)

---

🤖 Generated with [Gajae Code](https://github.com/twoimo/gajae-code)
